### PR TITLE
Implement Soulseek support via Slskd

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,23 @@ jobs:
           echo "Extracted version: $TAG_VERSION"
           echo "PACKAGE_VERSION=$TAG_VERSION" >> $GITHUB_ENV
 
+          # Log the extracted version
+          echo "Version: $TAG_VERSION"
+
+          # Check if the version is a pre-release (starts with 0.)
+          if [[ "$TAG_VERSION" == 0.* ]]; then
+            echo "This is a pre-release version."
+            echo "IS_PRERELEASE=true" >> $GITHUB_ENV
+          else
+            echo "This is a stable release."
+            echo "IS_PRERELEASE=false" >> $GITHUB_ENV
+          fi
+
+      - name: Log version and pre-release status
+        run: |
+          echo "Version: $PACKAGE_VERSION"
+          echo "Is Pre-release: $IS_PRERELEASE"
+
       - name: Extract repository name without owner
         id: extract_repo_name
         run: |
@@ -92,6 +109,7 @@ jobs:
         run: |
           echo "COMMIT_MESSAGES: $COMMIT_MESSAGES"
           echo "TAG_DESCRIPTION: $TAG_DESCRIPTION"
+          echo "IS_PRERELEASE: $IS_PRERELEASE"
 
       - name: Create GitHub Release and Upload Artifact
         uses: softprops/action-gh-release@v1

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
+Here’s the complete README with the added short notice under the **Troubleshooting** section:
 # Tubifarry for Lidarr 🎶  
 ![Downloads](https://img.shields.io/github/downloads/TypNull/Tubifarry/total)  ![GitHub release (latest by date)](https://img.shields.io/github/v/release/TypNull/Tubifarry)  ![GitHub last commit](https://img.shields.io/github/last-commit/TypNull/Tubifarry)  ![License](https://img.shields.io/github/license/TypNull/Tubifarry)  ![GitHub stars](https://img.shields.io/github/stars/TypNull/Tubifarry)  
 
-Tubifarry is a plugin for **Lidarr** that fetches metadata from **Spotify** and **YouTube**, enabling direct music downloads from YouTube. Built on the foundation of trevTV's projects, it leverages the YouTube API for seamless integration. 🛠️  
+Tubifarry is a versatile plugin for **Lidarr** that enhances your music library by fetching metadata from **Spotify** and enabling direct music downloads from **YouTube**. While it is not explicitly a Spotify-to-YouTube downloader, it leverages the YouTube API to seamlessly integrate music downloads into your Lidarr setup. Built on the foundation of trevTV's projects, Tubifarry also supports **Slskd**, the Soulseek client, as both an **indexer** and **downloader**, allowing you to tap into the vast music collection available on the Soulseek network. 🛠️  
 
-Additionally, Tubifarry supports fetching soundtracks from **Sonarr** (series) and **Radarr** (movies) and adding them to Lidarr using the **Arr-Soundtracks** import list feature. This allows you to easily manage and download soundtracks for your favorite movies and TV shows. 🎬🎵  
+Additionally, Tubifarry supports fetching soundtracks from **Sonarr** (series) and **Radarr** (movies) and adding them to Lidarr using the **Arr-Soundtracks** import list feature. This makes it easy to manage and download soundtracks for your favorite movies and TV shows. 🎬🎵  
 
 ---
 
@@ -26,21 +27,52 @@ To switch to the Plugins Branch:
 ---
 
 ### Plugin Installation 📥  
+- In Lidarr, go to `System -> Plugins`.  
+- Paste `https://github.com/TypNull/Tubifarry` into the GitHub URL box and click **Install**.  
 
-#### **For Docker Users**:  
-1. **Install the Plugin**:  
-   - In Lidarr, go to `System -> Plugins`.  
-   - Paste `https://github.com/TypNull/Tubifarry` into the GitHub URL box and click **Install**.  
+---
 
-2. **Configure the Indexer**:  
-   - Navigate to `Settings -> Indexers` and click **Add**.  
-   - In the modal, select `Tubifarry` (located under **Other** at the bottom).  
+### Soulseek (Slskd) Setup 🎧  
+Tubifarry supports **Slskd**, the Soulseek client, as both an **indexer** and **downloader**. Follow the steps below to configure it.  
 
-3. **Set Up the Download Client**:  
-   - Go to `Settings -> Download Clients` and click **Add**.  
-   - In the modal, choose `Youtube` (under **Other** at the bottom).  
-   - Set the download path and adjust other settings as needed.  
-   - **Optional**: If using FFmpeg, ensure the FFmpeg path is correctly configured.  
+#### **Setting Up the Soulseek Indexer**:  
+1. Navigate to `Settings -> Indexers` and click **Add**.  
+2. Select `Slskd` from the list of indexers.  
+3. Configure the following settings:  
+   - **URL**: The URL of your Slskd instance (e.g., `http://localhost:5030`).  
+   - **API Key**: The API key for your Slskd instance (found in Slskd's settings under 'Options').  
+   - **Include Only Audio Files**: Enable to filter search results to audio files only (beta).  
+
+#### **Setting Up the Soulseek Download Client**:  
+1. Go to `Settings -> Download Clients` and click **Add**.  
+2. Select `Slskd` from the list of download clients.  
+3. Set the **download path** where downloaded files will be downloaded.  
+
+---
+
+### YouTube Downloader Setup 🎥  
+Tubifarry allows you to download music directly from YouTube. Follow the steps below to configure the YouTube downloader.  
+
+#### **Setting Up the YouTube Download Client**:  
+1. Go to `Settings -> Download Clients` and click **Add**.  
+2. Select `Youtube` from the list of download clients.  
+3. Set the download path and adjust other settings as needed.  
+4. **Optional**: If using FFmpeg, ensure the FFmpeg path is correctly configured.  
+
+#### **FFmpeg and Audio Conversion**:  
+1. **FFmpeg**: FFmpeg can be used to extract audio from downloaded files, which are typically embedded in MP4 containers. If you choose to use FFmpeg, ensure it is installed and accessible in your system's PATH or the specified FFmpeg path. If not, the plugin does attempt to download it automatically during setup. Without FFmpeg, songs will be downloaded in their original format, which may not require additional processing.  
+
+   **Important Note**: If FFmpeg is not used, Lidarr may incorrectly interpret the MP4 container as corrupt. While FFmpeg usage is **recommended**, it is not strictly necessary. However, to avoid potential issues, you can choose to extract audio without re-encoding, but this may lead to better compatibility with Lidarr.
+
+2. **Max Audio Quality**: Tubifarry supports a maximum audio quality of **256kb/s AAC** for downloaded files through YouTube. While most files are in 128kbps AAC by default, they can be converted to higher-quality formats like **AAC, Opus or MP3v2** if FFmpeg is used.  
+
+   **What is AAC?**  
+   AAC (Advanced Audio Coding) is a high-quality audio format that offers better sound quality than MP3 at similar bitrates. It is commonly used in MP4 containers, making it a versatile and widely supported format.  
+
+   **Note**: For higher-quality audio (e.g., 256kb/s), you need a **YouTube Premium subscription**.  
+
+3. **Saving .lrc Files**:  
+   If you want to save **.lrc files** (lyric files), navigate to **Media Management > Advanced Settings > Import Extra Files** and add `lrc` to the list of supported file types. This ensures that lyric files are imported and saved alongside your music files.  
 
 ---
 
@@ -59,24 +91,8 @@ To enable this feature:
 
 ---
 
-### Optional: FFmpeg and Audio Quality 🎧  
-1. **FFmpeg**: FFmpeg can be used to extract audio from downloaded files, which are typically embedded in MP4 containers. If you choose to use FFmpeg, ensure it is installed and accessible in your system's PATH or the specified FFmpeg path. If not, the plugin does attempt to download it automatically during setup. Without FFmpeg, songs will be downloaded in their original format, which may not require additional processing.  
-
-   **Important Note**: If FFmpeg is not used, Lidarr may incorrectly interpret the MP4 container as corrupt. While FFmpeg usage is **recommended**, it is not strictly necessary. However, to avoid potential issues, you can choose to extract audio without re-encoding, but this may lead to better compatibility with Lidarr.
-
-2. **Max Audio Quality**: Tubifarry supports a maximum audio quality of **256kb/s AAC** for downloaded files through YouTube. While most files are in 128kbps AAC by default, they can be converted to higher-quality formats like **AAC, Opus or MP3v2** if FFmpeg is used.  
-
-   **What is AAC?**  
-   AAC (Advanced Audio Coding) is a high-quality audio format that offers better sound quality than MP3 at similar bitrates. It is commonly used in MP4 containers, making it a versatile and widely supported format.  
-
-   **Note**: For higher-quality audio (e.g., 256kb/s), you need a **YouTube Premium subscription**.  
-
-3. **Saving .lrc Files**:  
-   If you want to save **.lrc files** (lyric files), navigate to **Media Management > Advanced Settings > Import Extra Files** and add `lrc` to the list of supported file types. This ensures that lyric files are imported and saved alongside your music files.  
-
----
-
 ### Troubleshooting 🛠️  
+- **Slskd Download Path Permissions**: Ensure Lidarr has read/write access to the Slskd download path. Verify folder permissions and ensure the user running Lidarr has the necessary access. For Docker setups, confirm the volume is correctly mounted and permissions are set.  
 - **Optional: FFmpeg Issues**: If you choose to use FFmpeg and songs fail to process, verify that FFmpeg is correctly installed and accessible in your system's PATH. If not, try reinstalling or downloading it manually.  
 - **Metadata Issues**: If metadata is not being added to downloaded files, confirm that the files are in a supported format. If using FFmpeg, ensure it is extracting audio to formats like AAC embedded in MP4 containers (check debug logs).  
 - **No Release Found**: If no release is found, YouTube might flag the plugin as a bot (which it technically is). To avoid this and access higher-quality audio, you can log in using cookies.  
@@ -90,7 +106,7 @@ To enable this feature:
 ---
 
 ## Acknowledgments 🙌  
-Special thanks to **trevTV** for laying the groundwork with [Lidarr.Plugin.Tidal](https://github.com/TrevTV/Lidarr.Plugin.Tidal), [Lidarr.Plugin.Deezer](https://github.com/TrevTV/Lidarr.Plugin.Deezer), and [Lidarr.Plugin.Qobuz](https://github.com/TrevTV/Lidarr.Plugin.Qobuz). Additionally, thanks to [IcySnex/YouTubeMusicAPI](https://github.com/IcySnex/YouTubeMusicAPI) for providing the YouTube API. 🎉  
+Special thanks to [**trevTV**](https://github.com/TrevTV) for laying the groundwork with his plugins. Additionally, thanks to [**IcySnex**](https://github.com/IcySnex) for providing the YouTube API. 🎉  
 
 ---
 
@@ -100,8 +116,8 @@ If you'd like to contribute to Tubifarry, feel free to open issues or submit pul
 ---
 
 ## License 📄  
-Tubifarry is licensed under the MIT License. See the [LICENSE](https://github.com/TypNull/Tubifarry/blob/main/LICENSE) file for more details.  
+Tubifarry is licensed under the MIT License. See the [LICENSE](https://github.com/TypNull/Tubifarry/blob/master/LICENSE) file for more details.  
 
 ---
 
-Enjoy seamless music downloads with Tubifarry! 🎧  
+Enjoy seamless music downloads with Tubifarry! 🎧

--- a/Tubifarry/Blocklisting/Blocklists.cs
+++ b/Tubifarry/Blocklisting/Blocklists.cs
@@ -1,0 +1,14 @@
+using NzbDrone.Core.Indexers;
+
+namespace NzbDrone.Core.Blocklisting
+{
+    public class YoutubeBlocklist : BaseBlocklist<YoutubeDownloadProtocol>
+    {
+        public YoutubeBlocklist(IBlocklistRepository blocklistRepository) : base(blocklistRepository) { }
+    }
+
+    public class SoulseekBlocklist : BaseBlocklist<SoulseekDownloadProtocol>
+    {
+        public SoulseekBlocklist(IBlocklistRepository blocklistRepository) : base(blocklistRepository) { }
+    }
+}

--- a/Tubifarry/Core/AlbumData.cs
+++ b/Tubifarry/Core/AlbumData.cs
@@ -31,6 +31,7 @@ namespace Tubifarry.Core
 
         // Soulseek
         public long? Size { get; set; }
+        public int Priotity { get; set; }
 
         // Not used
         public AudioFormat Codec { get; set; } = AudioFormat.AAC;
@@ -47,7 +48,7 @@ namespace Tubifarry.Core
             Album = AlbumName,
             DownloadUrl = AlbumId,
             InfoUrl = InfoUrl,
-            PublishDate = ReleaseDateTime,
+            PublishDate = ReleaseDateTime == DateTime.MinValue ? DateTime.UtcNow : ReleaseDateTime,
             DownloadProtocol = nameof(YoutubeDownloadProtocol),
             Title = ConstructTitle(),
             Codec = Codec.ToString(),
@@ -101,7 +102,7 @@ namespace Tubifarry.Core
         /// </summary>
         /// <param name="albumName">The album name to normalize.</param>
         /// <returns>The normalized album name.</returns>
-        private string NormalizeAlbumName(string albumName)
+        private static string NormalizeAlbumName(string albumName)
         {
             Regex featRegex = new(@"(?i)\b(feat\.|ft\.|featuring)\b", RegexOptions.IgnoreCase);
             if (featRegex.IsMatch(albumName))

--- a/Tubifarry/Core/AlbumData.cs
+++ b/Tubifarry/Core/AlbumData.cs
@@ -22,7 +22,7 @@ namespace Tubifarry.Core
         public string ReleaseDatePrecision { get; set; } = string.Empty;
         public int TotalTracks { get; set; }
         public bool ExplicitContent { get; set; }
-        public string CoverUrl { get; set; } = string.Empty;
+        public string CustomString { get; set; } = string.Empty;
         public string CoverResolution { get; set; } = string.Empty;
 
         // Properties from YoutubeSearchResults
@@ -52,7 +52,7 @@ namespace Tubifarry.Core
             Title = ConstructTitle(),
             Codec = Codec.ToString(),
             Resolution = CoverResolution,
-            Source = CoverUrl,
+            Source = CustomString,
             Container = Bitrate.ToString(),
             Size = Size ?? (Duration > 0 ? Duration : TotalTracks * 300) * Bitrate * 1000 / 8
         };

--- a/Tubifarry/Core/AlbumData.cs
+++ b/Tubifarry/Core/AlbumData.cs
@@ -9,13 +9,14 @@ namespace Tubifarry.Core
     /// </summary>
     public class AlbumData
     {
+        public string IndexerName { get; }
         // Mixed
         public string AlbumId { get; set; } = string.Empty;
 
         // Properties from AlbumInfo
         public string AlbumName { get; set; } = string.Empty;
         public string ArtistName { get; set; } = string.Empty;
-        public string SpotifyUrl { get; set; } = string.Empty;
+        public string InfoUrl { get; set; } = string.Empty;
         public string ReleaseDate { get; set; } = string.Empty;
         public DateTime ReleaseDateTime { get; set; }
         public string ReleaseDatePrecision { get; set; } = string.Empty;
@@ -24,24 +25,28 @@ namespace Tubifarry.Core
         public string CoverUrl { get; set; } = string.Empty;
         public string CoverResolution { get; set; } = string.Empty;
 
-
         // Properties from YoutubeSearchResults
         public int Bitrate { get; set; }
         public long Duration { get; set; }
 
-        //Not used
+        // Soulseek
+        public long? Size { get; set; }
+
+        // Not used
         public AudioFormat Codec { get; set; } = AudioFormat.AAC;
+
+        public AlbumData(string name) => IndexerName = name;
 
         /// <summary>
         /// Converts AlbumData into a ReleaseInfo object.
         /// </summary>
         public ReleaseInfo ToReleaseInfo() => new()
         {
-            Guid = $"Tubifarry-{AlbumId}-{Bitrate}",
+            Guid = $"{IndexerName}-{AlbumId}-{Bitrate}",
             Artist = ArtistName,
             Album = AlbumName,
             DownloadUrl = AlbumId,
-            InfoUrl = SpotifyUrl,
+            InfoUrl = InfoUrl,
             PublishDate = ReleaseDateTime,
             DownloadProtocol = nameof(YoutubeDownloadProtocol),
             Title = ConstructTitle(),
@@ -49,9 +54,12 @@ namespace Tubifarry.Core
             Resolution = CoverResolution,
             Source = CoverUrl,
             Container = Bitrate.ToString(),
-            Size = (Duration > 0 ? Duration : TotalTracks * 300) * Bitrate * 1000 / 8
+            Size = Size ?? (Duration > 0 ? Duration : TotalTracks * 300) * Bitrate * 1000 / 8
         };
 
+        /// <summary>
+        /// Parses the release date based on the precision.
+        /// </summary>
         public void ParseReleaseDate() => ReleaseDateTime = ReleaseDatePrecision switch
         {
             "year" => new DateTime(int.Parse(ReleaseDate), 1, 1),
@@ -67,19 +75,23 @@ namespace Tubifarry.Core
         private string ConstructTitle()
         {
             string normalizedAlbumName = NormalizeAlbumName(AlbumName);
-            // Start with the basic format: Artist - Album
+
             string title = $"{ArtistName} - {normalizedAlbumName}";
 
-            // Add the release year if available
-            if (ReleaseDateTime.Year > 0)
+            if (ReleaseDateTime != DateTime.MinValue)
                 title += $" - {ReleaseDateTime.Year}";
 
-            // Add the explicit content indicator if applicable
             if (ExplicitContent)
                 title += " [Explicit]";
 
-            // Add the bitrate and source type
-            title += $" [{Codec} {Bitrate}kbps] [WEB]";
+            int calculatedBitrate = Bitrate;
+            if (calculatedBitrate <= 0 && Size.HasValue && Duration > 0)
+                calculatedBitrate = (int)((Size.Value * 8) / (Duration * 1000));
+
+            if (AudioFormatHelper.IsLossyFormat(Codec))
+                title += $" [{Codec} {calculatedBitrate}kbps] [WEB]";
+            else
+                title += $" [{Codec}] [WEB]";
 
             return title;
         }
@@ -91,19 +103,14 @@ namespace Tubifarry.Core
         /// <returns>The normalized album name.</returns>
         private string NormalizeAlbumName(string albumName)
         {
-            // Handle featuring artists (e.g., "feat.", "ft.", "Feat.", "Ft.", etc.)
             Regex featRegex = new(@"(?i)\b(feat\.|ft\.|featuring)\b", RegexOptions.IgnoreCase);
             if (featRegex.IsMatch(albumName))
             {
-                // Extract the featuring artist(s)
                 Match match = featRegex.Match(albumName);
                 string featuringArtist = albumName.Substring(match.Index + match.Length).Trim();
 
-                // Format the featuring artist(s) in a consistent way
                 albumName = $"{albumName.Substring(0, match.Index).Trim()} (feat. {featuringArtist})";
             }
-
-            // Replace content inside parentheses (except for featuring artists) with curly braces
             albumName = Regex.Replace(albumName, @"\((?!feat\.)[^)]*\)", match => $"{{{match.Value.Trim('(', ')')}}}");
 
             return albumName;

--- a/Tubifarry/Core/AudioFormat.cs
+++ b/Tubifarry/Core/AudioFormat.cs
@@ -21,17 +21,15 @@ namespace Tubifarry.Core
 
     internal static class AudioFormatHelper
     {
-
-        private static List<AudioFormat> _lossyFormats = new()
-            {
+        private static readonly AudioFormat[] _lossyFormats = new[] {
         AudioFormat.AAC,
         AudioFormat.MP3,
         AudioFormat.Opus,
         AudioFormat.Vorbis,
         AudioFormat.MP4,
         AudioFormat.AMR,
-        AudioFormat.WMA
-    };
+        AudioFormat.WMA  };
+
         /// <summary>
         /// Returns the correct file extension for a given audio codec.
         /// </summary>
@@ -69,6 +67,7 @@ namespace Tubifarry.Core
             "wma" => AudioFormat.WMA,
             _ => AudioFormat.Unknown // Default for unknown formats
         };
+
         /// <summary>
         /// Returns the file extension for a given audio format.
         /// </summary>

--- a/Tubifarry/Core/AudioFormat.cs
+++ b/Tubifarry/Core/AudioFormat.cs
@@ -21,6 +21,17 @@ namespace Tubifarry.Core
 
     internal static class AudioFormatHelper
     {
+
+        private static List<AudioFormat> _lossyFormats = new()
+            {
+        AudioFormat.AAC,
+        AudioFormat.MP3,
+        AudioFormat.Opus,
+        AudioFormat.Vorbis,
+        AudioFormat.MP4,
+        AudioFormat.AMR,
+        AudioFormat.WMA
+    };
         /// <summary>
         /// Returns the correct file extension for a given audio codec.
         /// </summary>
@@ -37,20 +48,27 @@ namespace Tubifarry.Core
             _ => ".aac" // Default to AAC if the codec is unknown
         };
 
+        public static bool IsLossyFormat(AudioFormat format) => _lossyFormats.Contains(format);
+
+
         /// <summary>
         /// Determines the audio format from a given codec string.
         /// </summary>
-        public static AudioFormat GetAudioFormatFromCodec(string codec) => codec switch
+        public static AudioFormat GetAudioFormatFromCodec(string codec) => codec?.ToLowerInvariant() switch
         {
-            "aac" => AudioFormat.AAC,
+            // Common codecs and extensions
+            "aac" or "m4a" or "mp4" => AudioFormat.AAC,
             "mp3" => AudioFormat.MP3,
             "opus" => AudioFormat.Opus,
-            "vorbis" => AudioFormat.Vorbis,
+            "vorbis" or "ogg" => AudioFormat.Vorbis,
             "flac" => AudioFormat.FLAC,
-            "pcm_s16le" or "pcm_s24le" or "pcm_s32le" => AudioFormat.WAV,
-            _ => AudioFormat.Unknown
+            "wav" or "pcm_s16le" or "pcm_s24le" or "pcm_s32le" => AudioFormat.WAV,
+            "aiff" or "aif" or "aifc" => AudioFormat.AIFF,
+            "mid" or "midi" => AudioFormat.MIDI,
+            "amr" => AudioFormat.AMR,
+            "wma" => AudioFormat.WMA,
+            _ => AudioFormat.Unknown // Default for unknown formats
         };
-
         /// <summary>
         /// Returns the file extension for a given audio format.
         /// </summary>

--- a/Tubifarry/Core/AudioFormat.cs
+++ b/Tubifarry/Core/AudioFormat.cs
@@ -22,13 +22,14 @@ namespace Tubifarry.Core
     internal static class AudioFormatHelper
     {
         private static readonly AudioFormat[] _lossyFormats = new[] {
-        AudioFormat.AAC,
-        AudioFormat.MP3,
-        AudioFormat.Opus,
-        AudioFormat.Vorbis,
-        AudioFormat.MP4,
-        AudioFormat.AMR,
-        AudioFormat.WMA  };
+            AudioFormat.AAC,
+            AudioFormat.MP3,
+            AudioFormat.Opus,
+            AudioFormat.Vorbis,
+            AudioFormat.MP4,
+            AudioFormat.AMR,
+            AudioFormat.WMA
+        };
 
         /// <summary>
         /// Returns the correct file extension for a given audio codec.
@@ -45,9 +46,6 @@ namespace Tubifarry.Core
             "pcm_s16le" or "pcm_s24le" or "pcm_s32le" => ".wav",
             _ => ".aac" // Default to AAC if the codec is unknown
         };
-
-        public static bool IsLossyFormat(AudioFormat format) => _lossyFormats.Contains(format);
-
 
         /// <summary>
         /// Determines the audio format from a given codec string.
@@ -79,7 +77,13 @@ namespace Tubifarry.Core
             AudioFormat.Vorbis => ".ogg",
             AudioFormat.FLAC => ".flac",
             AudioFormat.WAV => ".wav",
-            _ => ".aac"
+            AudioFormat.AIFF => ".aiff",
+            AudioFormat.MIDI => ".midi",
+            AudioFormat.AMR => ".amr",
+            AudioFormat.WMA => ".wma",
+            AudioFormat.MP4 => ".mp4",
+            AudioFormat.OGG => ".ogg",
+            _ => ".aac" // Default to AAC if the format is unknown
         };
 
         /// <summary>
@@ -92,6 +96,30 @@ namespace Tubifarry.Core
             ReEncodeOptions.Opus => AudioFormat.Opus,
             ReEncodeOptions.Vorbis => AudioFormat.Vorbis,
             _ => AudioFormat.Unknown
+        };
+
+        /// <summary>
+        /// Determines if a given format is lossy.
+        /// </summary>
+        public static bool IsLossyFormat(AudioFormat format) => _lossyFormats.Contains(format);
+
+        /// <summary>
+        /// Determines the audio format from a given file extension.
+        /// </summary>
+        public static AudioFormat GetAudioCodecFromExtension(string extension) => extension?.ToLowerInvariant().TrimStart('.') switch
+        {
+            // Common file extensions
+            "m4a" or "mp4" or "aac" => AudioFormat.AAC,
+            "mp3" => AudioFormat.MP3,
+            "opus" => AudioFormat.Opus,
+            "ogg" or "vorbis" => AudioFormat.Vorbis,
+            "flac" or "alac" => AudioFormat.FLAC,
+            "wav" => AudioFormat.WAV,
+            "aiff" or "aif" or "aifc" => AudioFormat.AIFF,
+            "mid" or "midi" => AudioFormat.MIDI,
+            "amr" => AudioFormat.AMR,
+            "wma" => AudioFormat.WMA,
+            _ => AudioFormat.Unknown // Default for unknown extensions
         };
     }
 }

--- a/Tubifarry/Download/Clients/Soulseek/SlskdClient.cs
+++ b/Tubifarry/Download/Clients/Soulseek/SlskdClient.cs
@@ -1,0 +1,215 @@
+﻿using FluentValidation.Results;
+using NLog;
+using NzbDrone.Common.Disk;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Indexers;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.RemotePathMappings;
+using System.Net;
+using System.Text.Json;
+
+namespace NzbDrone.Core.Download.Clients.Soulseek
+{
+    public class SlskdClient : DownloadClientBase<SlskdProviderSettings>
+    {
+        private readonly IHttpClient _httpClient;
+        private Dictionary<string, SlskdDownloadItem> _downloadMapping;
+        private string _downloadPath = string.Empty;
+        private bool _isLocalhost = false;
+
+        public SlskdClient(IHttpClient httpClient, IConfigService configService, IDiskProvider diskProvider, IRemotePathMappingService remotePathMappingService, Logger logger)
+            : base(configService, diskProvider, remotePathMappingService, logger)
+        {
+            _httpClient = httpClient;
+            _downloadMapping = new Dictionary<string, SlskdDownloadItem>();
+        }
+
+        public override string Name => "Slskd";
+
+        public override string Protocol => nameof(SoulseekDownloadProtocol);
+
+        public override async Task<string> Download(RemoteAlbum remoteAlbum, IIndexer indexer)
+        {
+            SlskdDownloadItem item = new(Guid.NewGuid().ToString(), remoteAlbum);
+            HttpRequest request = BuildHttpRequest(remoteAlbum.Release.DownloadUrl, HttpMethod.Post, remoteAlbum.Release.Source);
+            HttpResponse response = await _httpClient.ExecuteAsync(request);
+
+            if (response.StatusCode != HttpStatusCode.Created)
+                throw new DownloadClientException("Failed to create download.");
+
+            _downloadMapping[item.ID] = item;
+            return item.ID;
+        }
+
+        public override IEnumerable<DownloadClientItem> GetItems()
+        {
+            UpdateDownloadItemsAsync().Wait();
+            DownloadClientItemClientInfo clientInfo = DownloadClientItemClientInfo.FromDownloadClient(this, false);
+            foreach (KeyValuePair<string, SlskdDownloadItem> kpv in _downloadMapping)
+            {
+                DownloadClientItem clientItem = kpv.Value.GetDownloadClientItem(_downloadPath);
+                clientItem.DownloadClientInfo = clientInfo;
+                yield return clientItem;
+            }
+        }
+
+        public override void RemoveItem(DownloadClientItem clientItem, bool deleteData)
+        {
+            if (!deleteData) return;
+            _downloadMapping.TryGetValue(clientItem.DownloadId, out SlskdDownloadItem? slskdItem);
+            if (slskdItem == null) return;
+            RemoveItemAsync(slskdItem).Wait();
+            _downloadMapping.Remove(clientItem.DownloadId);
+        }
+
+        private async Task UpdateDownloadItemsAsync()
+        {
+            HttpRequest request = BuildHttpRequest("/api/v0/transfers/downloads/");
+            HttpResponse response = await _httpClient.ExecuteAsync(request);
+
+            if (response.StatusCode != HttpStatusCode.OK)
+                throw new DownloadClientException($"Failed to fetch downloads. Status Code: {response.StatusCode}");
+            List<JsonElement>? downloads = JsonSerializer.Deserialize<List<JsonElement>>(response.Content);
+            downloads?.ForEach(user =>
+            {
+                user.TryGetProperty("directories", out JsonElement directoriesElement);
+                IEnumerable<SlskdDownloadDirectory> data = SlskdDownloadDirectory.GetDirectories(directoriesElement);
+                foreach (SlskdDownloadDirectory dir in data)
+                {
+                    SlskdDownloadItem? item = _downloadMapping.Values.FirstOrDefault(x => x.FileData.Any(y => y.Filename?.Contains(dir.Directory!) ?? false));
+                    if (item == null)
+                        continue;
+                    item.Username ??= user.GetProperty("username").GetString()!;
+                    item.SlskdDownloadDirectory = dir;
+                }
+            });
+        }
+
+        private async Task<string?> FetchDownloadPathAsync()
+        {
+            try
+            {
+                HttpResponse response = await _httpClient.ExecuteAsync(BuildHttpRequest("/api/v0/options"));
+
+                if (response.StatusCode != HttpStatusCode.OK)
+                {
+                    _logger.Warn($"Failed to fetch options. Status Code: {response.StatusCode}");
+                    return null;
+                }
+
+                using JsonDocument doc = JsonDocument.Parse(response.Content);
+                if (doc.RootElement.TryGetProperty("directories", out JsonElement directories) &&
+                    directories.TryGetProperty("downloads", out JsonElement downloads)) return downloads.GetString();
+
+                _logger.Warn("Download path not found in the options.");
+                return null;
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Failed to fetch download path from Slskd.");
+            }
+
+            return null;
+        }
+
+        public override DownloadClientInfo GetStatus()
+        {
+            if (string.IsNullOrEmpty(_downloadPath))
+                _downloadPath = string.IsNullOrEmpty(Settings.DownloadPath) ? FetchDownloadPathAsync().Result ?? Settings.DownloadPath : Settings.DownloadPath;
+            return new DownloadClientInfo
+            {
+                IsLocalhost = _isLocalhost,
+                OutputRootFolders = new List<OsPath> { _remotePathMappingService.RemapRemoteToLocal(Settings.BaseUrl, new OsPath(_downloadPath)) }
+            };
+        }
+
+        protected override void Test(List<ValidationFailure> failures) => failures.AddIfNotNull(TestConnection().Result);
+
+        protected async Task<ValidationFailure> TestConnection()
+        {
+            try
+            {
+                Uri uri = new(Settings.BaseUrl);
+                if (uri.Host.Equals("localhost", StringComparison.OrdinalIgnoreCase) ||
+                    IPAddress.TryParse(uri.Host, out IPAddress? ipAddress) && IPAddress.IsLoopback(ipAddress))
+                    _isLocalhost = true;
+            }
+            catch (UriFormatException ex)
+            {
+                _logger.Warn($"Invalid BaseUrl format: {Settings.BaseUrl}");
+                return new ValidationFailure("BaseUrl", $"Invalid BaseUrl format: {ex.Message}");
+            }
+
+            try
+            {
+                HttpRequest request = BuildHttpRequest("/api/v0/application");
+                request.AllowAutoRedirect = true;
+                request.RequestTimeout = TimeSpan.FromSeconds(30);
+                HttpResponse response = await _httpClient.ExecuteAsync(request);
+
+                if (response.StatusCode != HttpStatusCode.OK)
+                    return new ValidationFailure("BaseUrl", $"Unable to connect to Slskd. Status: {response.StatusCode}");
+
+                using JsonDocument jsonDocument = JsonDocument.Parse(response.Content);
+                JsonElement jsonResponse = jsonDocument.RootElement;
+
+                if (!jsonResponse.TryGetProperty("server", out JsonElement serverElement) ||
+                    !serverElement.TryGetProperty("state", out JsonElement stateElement))
+                    return new ValidationFailure("BaseUrl", "Failed to parse Slskd response: missing 'server' or 'state'.");
+
+
+                string? serverState = stateElement.GetString();
+                if (string.IsNullOrEmpty(serverState) || !serverState.Contains("Connected"))
+                    return new ValidationFailure("BaseUrl", $"Slskd server is not connected. State: {serverState}");
+
+
+                _downloadPath = string.IsNullOrEmpty(Settings.DownloadPath) ? await FetchDownloadPathAsync() ?? Settings.DownloadPath : Settings.DownloadPath;
+                if (string.IsNullOrEmpty(_downloadPath))
+                    return new ValidationFailure("DownloadPath", "DownloadPath could not be found or is invalid.");
+                return null!;
+            }
+            catch (HttpException ex)
+            {
+                return new ValidationFailure("BaseUrl", $"Unable to connect to Slskd: {ex.Message}");
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Unexpected error while testing Slskd connection.");
+                return new ValidationFailure(string.Empty, $"Unexpected error: {ex.Message}");
+            }
+        }
+
+        private HttpRequest BuildHttpRequest(string endpoint, HttpMethod? method = null, string? content = null)
+        {
+            HttpRequestBuilder requestBuilder = new HttpRequestBuilder($"{Settings.BaseUrl}{endpoint}")
+                .SetHeader("X-API-KEY", Settings.ApiKey)
+                .SetHeader("Accept", "application/json");
+
+            if (method != null)
+                requestBuilder.Method = method;
+
+            bool hasContent = !string.IsNullOrEmpty(content);
+            if (hasContent)
+                requestBuilder.SetHeader("Content-Type", "application/json");
+
+            HttpRequest request = requestBuilder.Build();
+            if (hasContent)
+                request.SetContent(content);
+            return request;
+        }
+
+        private async Task RemoveItemAsync(SlskdDownloadItem item)
+        {
+            HttpResponse response = await _httpClient.ExecuteAsync(BuildHttpRequest($"/api/v0/transfers/downloads/{item.Username}/{item.ID}", HttpMethod.Delete));
+
+            if (response.StatusCode != HttpStatusCode.NoContent)
+                _logger.Warn($"Failed to remove download with ID {item.ID}. Status Code: {response.StatusCode}");
+            else
+                _logger.Info($"Successfully removed download with ID {item.ID}.");
+        }
+
+        private async Task<HttpResponse> ExecuteAsync(HttpRequest request) => await _httpClient.ExecuteAsync(request);
+    }
+}

--- a/Tubifarry/Download/Clients/Soulseek/SlskdModels.cs
+++ b/Tubifarry/Download/Clients/Soulseek/SlskdModels.cs
@@ -1,0 +1,131 @@
+﻿using NzbDrone.Common.Disk;
+using NzbDrone.Core.Indexers.Soulseek;
+using NzbDrone.Core.Parser.Model;
+using System.Text.Json;
+
+namespace NzbDrone.Core.Download.Clients.Soulseek
+{
+    class SlskdDownloadItem
+    {
+        private readonly DownloadClientItem _downloadClientItem;
+
+        public string ID { get; set; } = string.Empty;
+        public List<SlskdFileData> FileData { get; set; } = new();
+        public string Username { get; set; } = string.Empty;
+        public RemoteAlbum RemoteAlbum { get; set; }
+        public SlskdDownloadDirectory? SlskdDownloadDirectory { get; set; }
+
+        public SlskdDownloadItem(string id, RemoteAlbum remoteAlbum)
+        {
+            ID = id;
+            RemoteAlbum = remoteAlbum;
+            FileData = JsonSerializer.Deserialize<List<SlskdFileData>>(RemoteAlbum.Release.Source) ?? new();
+            _downloadClientItem = new() { DownloadId = ID, CanBeRemoved = true, CanMoveFiles = true };
+        }
+
+        public DownloadClientItem GetDownloadClientItem(string downloadPath)
+        {
+            _downloadClientItem.OutputPath = new OsPath(Path.Combine(downloadPath, SlskdDownloadDirectory?.Directory ?? ""));
+            _downloadClientItem.Title = RemoteAlbum.Release.Title;
+            if (SlskdDownloadDirectory?.Files == null)
+                return _downloadClientItem;
+
+            long totalSize = SlskdDownloadDirectory.Files.Sum(file => file.Size);
+            long remainingSize = SlskdDownloadDirectory.Files.Sum(file => file.BytesRemaining);
+            TimeSpan? remainingTime = SlskdDownloadDirectory.Files.Any()
+                ? SlskdDownloadDirectory.Files.Max(file => file.RemainingTime) : null;
+
+            DownloadItemStatus status = DownloadItemStatus.Queued;
+
+            if (SlskdDownloadDirectory.Files.All(file => file.IsCompleted))
+                status = DownloadItemStatus.Completed;
+            else if (SlskdDownloadDirectory.Files.Any(file => file.IsFailed))
+                status = DownloadItemStatus.Failed;
+            else if (SlskdDownloadDirectory.Files.Any(file => file.IsPaused))
+                status = DownloadItemStatus.Paused;
+            else if (SlskdDownloadDirectory.Files.Any(file => file.IsDownloading))
+                status = DownloadItemStatus.Downloading;
+            else if (SlskdDownloadDirectory.Files.Any(file => file.IsWarning))
+                status = DownloadItemStatus.Warning;
+
+            _downloadClientItem.TotalSize = totalSize;
+            _downloadClientItem.RemainingSize = remainingSize;
+            _downloadClientItem.RemainingTime = remainingTime;
+            _downloadClientItem.Status = status;
+            return _downloadClientItem;
+        }
+    }
+
+    public record SlskdDownloadDirectory(string Directory, int FileCount, List<SlskdDownloadFile>? Files)
+    {
+        public static IEnumerable<SlskdDownloadDirectory> GetDirectories(JsonElement directoriesElement)
+        {
+            if (directoriesElement.ValueKind != JsonValueKind.Array)
+                yield break;
+
+            foreach (JsonElement directory in directoriesElement.EnumerateArray())
+            {
+                yield return new SlskdDownloadDirectory(
+                    Directory: directory.TryGetProperty("directory", out JsonElement directoryElement) ? directoryElement.GetString() ?? string.Empty : string.Empty,
+                    FileCount: directory.TryGetProperty("fileCount", out JsonElement fileCountElement) ? fileCountElement.GetInt32() : 0,
+                    Files: directory.TryGetProperty("files", out JsonElement filesElement) ? SlskdDownloadFile.GetFiles(filesElement).ToList() : new List<SlskdDownloadFile>()
+                );
+            }
+        }
+    }
+
+    public record SlskdDownloadFile(
+        string Id,
+        string Username,
+        string Direction,
+        string Filename,
+        long Size,
+        long StartOffset,
+        string State,
+        DateTime RequestedAt,
+        DateTime EnqueuedAt,
+        DateTime StartedAt,
+        long BytesTransferred,
+        double AverageSpeed,
+        long BytesRemaining,
+        TimeSpan ElapsedTime,
+        double PercentComplete,
+        TimeSpan RemainingTime
+    )
+    {
+        public bool IsCompleted => State == "Completed";
+        public bool IsFailed => State == "Failed";
+        public bool IsPaused => State == "Paused";
+        public bool IsDownloading => State == "Downloading";
+        public bool IsWarning => State == "Warning";
+        public bool IsQueued => State == "Queued";
+
+        public static IEnumerable<SlskdDownloadFile> GetFiles(JsonElement filesElement)
+        {
+            if (filesElement.ValueKind != JsonValueKind.Array)
+                yield break;
+
+            foreach (JsonElement file in filesElement.EnumerateArray())
+            {
+                yield return new SlskdDownloadFile(
+                    Id: file.TryGetProperty("id", out JsonElement id) ? id.GetString() ?? string.Empty : string.Empty,
+                    Username: file.TryGetProperty("username", out JsonElement username) ? username.GetString() ?? string.Empty : string.Empty,
+                    Direction: file.TryGetProperty("direction", out JsonElement direction) ? direction.GetString() ?? string.Empty : string.Empty,
+                    Filename: file.TryGetProperty("filename", out JsonElement filename) ? filename.GetString() ?? string.Empty : string.Empty,
+                    Size: file.TryGetProperty("size", out JsonElement size) ? size.GetInt64() : 0L,
+                    StartOffset: file.TryGetProperty("startOffset", out JsonElement startOffset) ? startOffset.GetInt64() : 0L,
+                    State: file.TryGetProperty("state", out JsonElement state) ? state.GetString() ?? string.Empty : string.Empty,
+                    RequestedAt: file.TryGetProperty("requestedAt", out JsonElement requestedAt) && DateTime.TryParse(requestedAt.GetString(), out DateTime requestedAtParsed) ? requestedAtParsed : DateTime.MinValue,
+                    EnqueuedAt: file.TryGetProperty("enqueuedAt", out JsonElement enqueuedAt) && DateTime.TryParse(enqueuedAt.GetString(), out DateTime enqueuedAtParsed) ? enqueuedAtParsed : DateTime.MinValue,
+                    StartedAt: file.TryGetProperty("startedAt", out JsonElement startedAt) && DateTime.TryParse(startedAt.GetString(), out DateTime startedAtParsed) ? startedAtParsed : DateTime.MinValue,
+                    BytesTransferred: file.TryGetProperty("bytesTransferred", out JsonElement bytesTransferred) ? bytesTransferred.GetInt64() : 0L,
+                    AverageSpeed: file.TryGetProperty("averageSpeed", out JsonElement averageSpeed) ? averageSpeed.GetDouble() : 0.0,
+                    BytesRemaining: file.TryGetProperty("bytesRemaining", out JsonElement bytesRemaining) ? bytesRemaining.GetInt64() : 0L,
+                    ElapsedTime: file.TryGetProperty("elapsedTime", out JsonElement elapsedTime) && TimeSpan.TryParse(elapsedTime.GetString(), out TimeSpan elapsedTimeParsed) ? elapsedTimeParsed : TimeSpan.Zero,
+                    PercentComplete: file.TryGetProperty("percentComplete", out JsonElement percentComplete) ? percentComplete.GetDouble() : 0.0,
+                    RemainingTime: file.TryGetProperty("remainingTime", out JsonElement remainingTime) && TimeSpan.TryParse(remainingTime.GetString(), out TimeSpan remainingTimeParsed) ? remainingTimeParsed : TimeSpan.Zero
+                );
+            }
+        }
+    }
+}

--- a/Tubifarry/Download/Clients/Soulseek/SlskdProviderSettings.cs
+++ b/Tubifarry/Download/Clients/Soulseek/SlskdProviderSettings.cs
@@ -49,6 +49,12 @@ namespace NzbDrone.Core.Download.Clients.Soulseek
         [FieldDefinition(3, Label = "Download Path", Type = FieldType.Path, HelpText = "Specify the directory where downloaded files will be saved. If not specified, Slskd's default download path is used.")]
         public string DownloadPath { get; set; } = string.Empty;
 
+        [FieldDefinition(4, Label = "Is Fetched remote", Type = FieldType.Checkbox, Hidden = HiddenType.Hidden)]
+        public bool IsRemotePath { get; set; }
+
+        [FieldDefinition(4, Label = "Is Localhost", Type = FieldType.Checkbox, Hidden = HiddenType.Hidden)]
+        public bool IsLocalhost { get; set; }
+
         public NzbDroneValidationResult Validate() => new(Validator.Validate(this));
     }
 }

--- a/Tubifarry/Download/Clients/Soulseek/SlskdProviderSettings.cs
+++ b/Tubifarry/Download/Clients/Soulseek/SlskdProviderSettings.cs
@@ -1,0 +1,54 @@
+﻿using FluentValidation;
+using NzbDrone.Core.Annotations;
+using NzbDrone.Core.ThingiProvider;
+using NzbDrone.Core.Validation;
+
+namespace NzbDrone.Core.Download.Clients.Soulseek
+{
+    internal class SlskdProviderSettingsValidator : AbstractValidator<SlskdProviderSettings>
+    {
+        public SlskdProviderSettingsValidator()
+        {
+            // Base URL validation
+            RuleFor(c => c.BaseUrl)
+                .ValidRootUrl()
+                .Must(url => !url.EndsWith("/"))
+                .WithMessage("Base URL must not end with a slash ('/').");
+
+            // External URL validation (only if not empty)
+            RuleFor(c => c.ExternalUrl)
+                .Must(url => string.IsNullOrEmpty(url) || (Uri.IsWellFormedUriString(url, UriKind.Absolute) && !url.EndsWith("/")))
+                .WithMessage("External URL must be a valid URL and must not end with a slash ('/').");
+
+            // API Key validation
+            RuleFor(c => c.ApiKey)
+                .NotEmpty()
+                .WithMessage("API Key is required.");
+
+            // Validate DownloadPath can be null or empty, or a valid directory path
+            RuleFor(x => x.DownloadPath)
+                .Must(path => string.IsNullOrEmpty(path) || Path.IsPathRooted(path))
+                .WithMessage("Download path must be a valid directory path.")
+                .When(x => !string.IsNullOrEmpty(x.DownloadPath));
+        }
+    }
+
+    public class SlskdProviderSettings : IProviderConfig
+    {
+        private static readonly SlskdProviderSettingsValidator Validator = new();
+
+        [FieldDefinition(0, Label = "URL", Type = FieldType.Url, Placeholder = "http://localhost:5030", HelpText = "The URL of your Slskd instance.")]
+        public string BaseUrl { get; set; } = "http://localhost:5030";
+
+        [FieldDefinition(1, Label = "External URL", Type = FieldType.Url, Placeholder = "https://slskd.example.com", HelpText = "An optional external URL for additional resources or documentation.", Advanced = true)]
+        public string? ExternalUrl { get; set; } = string.Empty;
+
+        [FieldDefinition(2, Label = "API Key", Type = FieldType.Textbox, Privacy = PrivacyLevel.ApiKey, HelpText = "The API key for your Slskd instance. You can find or set this in the Slskd's settings under 'Options'.", Placeholder = "Enter your API key")]
+        public string ApiKey { get; set; } = string.Empty;
+
+        [FieldDefinition(3, Label = "Download Path", Type = FieldType.Path, HelpText = "Specify the directory where downloaded files will be saved. If not specified, Slskd's default download path is used.")]
+        public string DownloadPath { get; set; } = string.Empty;
+
+        public NzbDroneValidationResult Validate() => new(Validator.Validate(this));
+    }
+}

--- a/Tubifarry/Download/Clients/YouTube/YoutubeDownloadManager.cs
+++ b/Tubifarry/Download/Clients/YouTube/YoutubeDownloadManager.cs
@@ -27,10 +27,10 @@ namespace NzbDrone.Download.Clients.YouTube
     public class YoutubeDownloadManager : IYoutubeDownloadManager
     {
         private readonly RequestContainer<YouTubeAlbumRequest> _queue;
+        private readonly Logger _logger;
         private YouTubeMusicClient _ytClient;
         private Task? _testTask;
         private string? _cookiePath;
-        private Logger _logger;
 
 
         /// <summary>
@@ -42,7 +42,6 @@ namespace NzbDrone.Download.Clients.YouTube
             _logger = logger;
             _queue = new();
             _ytClient = new YouTubeMusicClient();
-            _logger.Trace("Initialized");
         }
 
         public void SetCookies(string path)

--- a/Tubifarry/Download/Clients/YouTubeAlbumRequest.cs
+++ b/Tubifarry/Download/Clients/YouTubeAlbumRequest.cs
@@ -36,7 +36,6 @@ namespace Tubifarry.Download.Clients
         private byte[]? _albumCover;
 
         private ReleaseInfo ReleaseInfo => _remoteAlbum.Release;
-
         public override Task Task => _requestContainer.Task;
         public override RequestState State => _requestContainer.State;
         public string ID { get; } = Guid.NewGuid().ToString();
@@ -88,7 +87,6 @@ namespace Tubifarry.Download.Clients
         {
             string albumBrowseID = await Options.YouTubeMusicClient!.GetAlbumBrowseIdAsync(ReleaseInfo.DownloadUrl, token).ConfigureAwait(false);
             AlbumInfo albumInfo = await Options.YouTubeMusicClient.GetAlbumInfoAsync(albumBrowseID, token).ConfigureAwait(false);
-            _logger.Info(Options.NameingConfig.StandardTrackFormat);
             if (albumInfo?.Songs == null || !albumInfo.Songs.Any())
             {
                 LogAndAppendMessage($"No tracks to download found in the album: {ReleaseInfo.Album}", LogLevel.Debug);
@@ -268,7 +266,6 @@ namespace Tubifarry.Download.Clients
                 ReadOnlyMemory<char> chunk = chunkEnumerator.Current;
                 distinctMessages.Add(chunk.ToString());
             }
-
             return string.Join("", distinctMessages);
         }
 

--- a/Tubifarry/ILRepack.targets
+++ b/Tubifarry/ILRepack.targets
@@ -8,6 +8,7 @@
 			<InputAssemblies Include="$(OutputPath)Requests.dll" />
 			<InputAssemblies Include="$(OutputPath)Xabe.FFmpeg.dll" />
 			<InputAssemblies Include="$(OutputPath)Xabe.FFmpeg.Downloader.dll" />
+			<InputAssemblies Include="$(OutputPath)FuzzySharp.dll" />
 			<InputAssemblies Include="$(OutputPath)Microsoft.Extensions.Logging.Abstractions.dll" />
 		</ItemGroup>
 

--- a/Tubifarry/ImportLists/ArrStack/ArrSoundtrackImport.cs
+++ b/Tubifarry/ImportLists/ArrStack/ArrSoundtrackImport.cs
@@ -122,6 +122,5 @@ namespace NzbDrone.Core.ImportLists.ArrStack
             APIItemEndpoint = apiItemEndpoint,
             APIStatusEndpoint = apiStatusEndpoint
         };
-
     }
 }

--- a/Tubifarry/ImportLists/ArrStack/ArrSoundtrackImportSettings.cs
+++ b/Tubifarry/ImportLists/ArrStack/ArrSoundtrackImportSettings.cs
@@ -75,7 +75,6 @@ namespace NzbDrone.Core.ImportLists.ArrStack
         [FieldDefinition(7, Label = "Refresh Interval", Type = FieldType.Textbox, HelpText = "The interval in hours to refresh the import list. Fractional values are allowed (e.g., 1.5 for 1 hour and 30 minutes).", Advanced = true, Placeholder = "12")]
         public double RefreshInterval { get; set; } = 12.0;
 
-
         public NzbDroneValidationResult Validate() => new(Validator.Validate(this));
     }
 }

--- a/Tubifarry/ImportLists/ArrStack/ArrSoundtrackRequestGenerator.cs
+++ b/Tubifarry/ImportLists/ArrStack/ArrSoundtrackRequestGenerator.cs
@@ -6,10 +6,8 @@ namespace NzbDrone.Core.ImportLists.ArrStack
     {
         public ArrSoundtrackImportSettings Settings { get; set; }
 
-        public ArrSoundtrackRequestGenerator(ArrSoundtrackImportSettings settings)
-        {
-            Settings = settings;
-        }
+        public ArrSoundtrackRequestGenerator(ArrSoundtrackImportSettings settings) => Settings = settings;
+
 
         public ImportListPageableRequestChain GetListItems()
         {

--- a/Tubifarry/ImportLists/MusicBrainzData.cs
+++ b/Tubifarry/ImportLists/MusicBrainzData.cs
@@ -1,6 +1,6 @@
 ﻿using System.Xml.Linq;
 
-namespace Tubifarry.ImportLists
+namespace NzbDrone.Core.ImportLists
 {
     public record MusicBrainzSearchItem(string? Title, string? AlbumId, string? Artist, string? ArtistId, DateTime ReleaseDate)
     {

--- a/Tubifarry/ImportLists/Spotify/SpotifyUserPlaylistImport.cs
+++ b/Tubifarry/ImportLists/Spotify/SpotifyUserPlaylistImport.cs
@@ -8,8 +8,6 @@ using NzbDrone.Core.Parser;
 using NzbDrone.Core.ThingiProvider;
 using SpotifyAPI.Web;
 using SpotifyAPI.Web.Models;
-using System.Security.Cryptography;
-using System.Text;
 using Tubifarry.Core;
 
 namespace NzbDrone.Core.ImportLists.Spotify
@@ -148,7 +146,6 @@ namespace NzbDrone.Core.ImportLists.Spotify
             };
 
             _fileCache!.SetAsync(cacheKey, cachedDataToSave, TimeSpan.FromDays(Settings.CacheRetentionDays)).Wait();
-
             result.AddRange(playlistItems);
         }
 
@@ -174,13 +171,12 @@ namespace NzbDrone.Core.ImportLists.Spotify
             public SimplePlaylist? Playlist { get; set; }
         }
 
-        private string GenerateCacheKey(string playlistId, string username)
+        private static string GenerateCacheKey(string playlistId, string username)
         {
-            string hashInput = $"{playlistId}_{username}";
-            using SHA256 sha256 = SHA256.Create();
-            byte[] hashBytes = sha256.ComputeHash(Encoding.UTF8.GetBytes(hashInput));
-            string hash = BitConverter.ToString(hashBytes).Replace("-", "")[..10].ToLower();
-            return hash;
+            HashCode hash = new();
+            hash.Add(playlistId);
+            hash.Add(username);
+            return hash.ToHashCode().ToString("x8");
         }
 
         private Paging<SimplePlaylist> GetUserPlaylistsWithRetry(SpotifyWebAPI api, string userId, int retryCount = 0)

--- a/Tubifarry/ImportLists/Spotify/SpotifyUserPlaylistImportSettings.cs
+++ b/Tubifarry/ImportLists/Spotify/SpotifyUserPlaylistImportSettings.cs
@@ -5,8 +5,7 @@ namespace NzbDrone.Core.ImportLists.Spotify
 {
     public class SpotifyUserPlaylistImportSettingsValidator : SpotifySettingsBaseValidator<SpotifyUserPlaylistImportSettings>
     {
-        public SpotifyUserPlaylistImportSettingsValidator()
-        : base()
+        public SpotifyUserPlaylistImportSettingsValidator() : base()
         {
             RuleFor(c => c.RefreshInterval)
                 .GreaterThanOrEqualTo(2)

--- a/Tubifarry/Indexers/DownloadProtocols.cs
+++ b/Tubifarry/Indexers/DownloadProtocols.cs
@@ -1,4 +1,5 @@
 namespace NzbDrone.Core.Indexers
 {
     public class YoutubeDownloadProtocol : IDownloadProtocol { }
+    public class SoulseekDownloadProtocol : IDownloadProtocol { }
 }

--- a/Tubifarry/Indexers/Soulseek/SlskdIndexer.cs
+++ b/Tubifarry/Indexers/Soulseek/SlskdIndexer.cs
@@ -1,0 +1,74 @@
+﻿using FluentValidation.Results;
+using NLog;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Parser;
+using System.Net;
+
+namespace NzbDrone.Core.Indexers.Soulseek
+{
+    public class SlskdIndexer : HttpIndexerBase<SlskdSettings>
+    {
+        public override string Name => "Slsdk";
+        public override string Protocol => nameof(SoulseekDownloadProtocol);
+        public override bool SupportsRss => false;
+        public override bool SupportsSearch => true;
+        public override int PageSize => 50;
+        public override TimeSpan RateLimit => new(3);
+
+        private readonly IIndexerRequestGenerator _indexerRequestGenerator;
+
+        private readonly IParseIndexerResponse _parseIndexerResponse;
+
+        internal new SlskdSettings Settings => base.Settings;
+
+
+        public SlskdIndexer(IHttpClient httpClient, IIndexerStatusService indexerStatusService, IConfigService configService, IParsingService parsingService, Logger logger)
+          : base(httpClient, indexerStatusService, configService, parsingService, logger)
+        {
+            _parseIndexerResponse = new SlskdParser();
+            _indexerRequestGenerator = new SlskdRequestGenerator(this, httpClient);
+        }
+
+        protected override async Task Test(List<ValidationFailure> failures) => failures.AddIfNotNull(await TestConnection());
+
+        public override IIndexerRequestGenerator GetRequestGenerator() => _indexerRequestGenerator;
+
+        public override IParseIndexerResponse GetParser() => _parseIndexerResponse;
+
+        protected override async Task<ValidationFailure> TestConnection()
+        {
+            try
+            {
+                HttpRequest request = new HttpRequestBuilder($"{Settings.BaseUrl}/api/v0/application")
+                    .SetHeader("X-API-KEY", Settings.ApiKey)
+                    .Build();
+
+                request.AllowAutoRedirect = true;
+                request.RequestTimeout = TimeSpan.FromSeconds(30);
+                HttpResponse response = await _httpClient.GetAsync(request);
+                _logger.Info(response.Content.ToString());
+                if (response.StatusCode == HttpStatusCode.OK)
+                    return null!;
+
+                else if (response.StatusCode == HttpStatusCode.Unauthorized)
+                    return new ValidationFailure("ApiKey", "Invalid API key");
+                else
+
+                    return new ValidationFailure("BaseUrl", $"Unable to connect to Slskd. Status: {response.StatusCode}");
+
+            }
+            catch (HttpException ex)
+            {
+                _logger.Warn(ex, "Unable to connect to Slskd");
+                return new ValidationFailure("BaseUrl", $"Unable to connect to Slskd: {ex.Message}");
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Unexpected error while testing Slskd connection");
+                return new ValidationFailure(string.Empty, $"Unexpected error: {ex.Message}");
+            }
+        }
+    }
+}

--- a/Tubifarry/Indexers/Soulseek/SlskdIndexer.cs
+++ b/Tubifarry/Indexers/Soulseek/SlskdIndexer.cs
@@ -42,13 +42,12 @@ namespace NzbDrone.Core.Indexers.Soulseek
             try
             {
                 HttpRequest request = new HttpRequestBuilder($"{Settings.BaseUrl}/api/v0/application")
-                    .SetHeader("X-API-KEY", Settings.ApiKey)
-                    .Build();
+                    .SetHeader("X-API-KEY", Settings.ApiKey).Build();
                 request.AllowAutoRedirect = true;
                 request.RequestTimeout = TimeSpan.FromSeconds(30);
 
                 HttpResponse response = await _httpClient.ExecuteAsync(request);
-                _logger.Info($"TestConnection Response: {response.Content}");
+                _logger.Debug($"TestConnection Response: {response.Content}");
 
                 if (response.StatusCode != HttpStatusCode.OK)
                     return new ValidationFailure("BaseUrl", $"Unable to connect to Slskd. Status: {response.StatusCode}");

--- a/Tubifarry/Indexers/Soulseek/SlskdParser.cs
+++ b/Tubifarry/Indexers/Soulseek/SlskdParser.cs
@@ -1,4 +1,6 @@
-﻿using NLog;
+﻿using Newtonsoft.Json;
+using NLog;
+using NzbDrone.Common.Http;
 using NzbDrone.Common.Instrumentation;
 using NzbDrone.Core.Parser.Model;
 using System.Text.Json;
@@ -8,44 +10,45 @@ namespace NzbDrone.Core.Indexers.Soulseek
 {
     public class SlskdParser : IParseIndexerResponse
     {
+        private readonly SlskdIndexer _indexer;
         private readonly Logger _logger;
+        private readonly IHttpClient _httpClient;
+        private SlskdSettings Settings => _indexer.Settings;
 
-        public SlskdParser() => _logger = NzbDroneLogger.GetLogger(this);
-
+        public SlskdParser(SlskdIndexer indexer, IHttpClient htmlClient)
+        {
+            _indexer = indexer;
+            _logger = NzbDroneLogger.GetLogger(this);
+            _httpClient = htmlClient;
+        }
 
         public IList<ReleaseInfo> ParseResponse(IndexerResponse indexerResponse)
         {
             List<ReleaseInfo> releases = new();
-
             try
             {
                 using JsonDocument jsonDoc = JsonDocument.Parse(indexerResponse.Content);
                 JsonElement root = jsonDoc.RootElement;
 
-                if (!root.TryGetProperty("searchText", out JsonElement searchTextElement) ||
-                    !root.TryGetProperty("responses", out JsonElement responsesElement))
+                if (!root.TryGetProperty("searchText", out JsonElement searchTextElement) || !root.TryGetProperty("responses", out JsonElement responsesElement) || !root.TryGetProperty("id", out JsonElement idElement))
                 {
-                    _logger.Warn("Required fields are missing in the slskd search response.");
+                    _logger.Error("Required fields are missing in the slskd search response.");
                     return releases;
                 }
 
-                string? searchText = searchTextElement.GetString();
-                SlskdSearchTextData searchTextData = SlskdSearchTextData.ParseSearchText(searchText ?? string.Empty);
+                SlskdSearchTextData searchTextData = SlskdSearchTextData.ParseSearchText(searchTextElement.GetString() ?? string.Empty);
 
                 foreach (JsonElement responseElement in GetResponses(responsesElement))
                 {
                     if (!responseElement.TryGetProperty("fileCount", out JsonElement fileCountElement) || fileCountElement.GetInt32() == 0)
                         continue;
-
-                    string? username = responseElement.TryGetProperty("username", out JsonElement usernameElement) ? usernameElement.GetString() : "Unknown User";
-
                     if (!responseElement.TryGetProperty("files", out JsonElement filesElement))
                         continue;
 
+                    string username = responseElement.TryGetProperty("username", out JsonElement usernameElement) ? usernameElement.GetString() ?? "Unknown User" : "Unknown User";
+
                     List<SlskdFileData> files = SlskdFileData.GetFiles(filesElement).ToList();
-                    List<IGrouping<string, SlskdFileData>> directories = files
-                        .GroupBy(f => f.Filename?[..f.Filename.LastIndexOf('\\')] ?? "")
-                        .ToList();
+                    List<IGrouping<string, SlskdFileData>> directories = files.GroupBy(f => f.Filename?[..f.Filename.LastIndexOf('\\')] ?? "").ToList();
 
                     foreach (IGrouping<string, SlskdFileData>? directory in directories)
                     {
@@ -53,21 +56,21 @@ namespace NzbDrone.Core.Indexers.Soulseek
                             continue;
 
                         SlskdFolderData folderData = SlskdFolderData.ParseFolderName(directory.Key);
-                        AlbumData albumData = CreateAlbumData(directory, username ?? "Unknown Username", searchTextData, folderData);
-
+                        AlbumData albumData = CreateAlbumData(idElement.GetString()!, directory, username, searchTextData, folderData);
                         releases.Add(albumData.ToReleaseInfo());
                     }
                 }
+                if (idElement.GetString() is string searchID)
+                    RemoveSearch(searchID).Wait();
             }
             catch (Exception ex)
             {
                 _logger.Error(ex, "Failed to parse Slskd search response.");
             }
-
             return releases.OrderByDescending(r => r.Size).ToList();
         }
 
-        private AlbumData CreateAlbumData(IGrouping<string, SlskdFileData> directory, string username, SlskdSearchTextData searchTextData, SlskdFolderData folderData)
+        private AlbumData CreateAlbumData(string searchId, IGrouping<string, SlskdFileData> directory, string username, SlskdSearchTextData searchTextData, SlskdFolderData folderData)
         {
             string hash = $"{username} {directory.Key}".GetHashCode().ToString("X");
 
@@ -89,38 +92,29 @@ namespace NzbDrone.Core.Indexers.Soulseek
             if (!bitRate.HasValue && totalDuration > 0)
                 bitRate = (int)((totalSize * 8) / (totalDuration * 1000));
 
+            List<SlskdFileData>? filesToDownload = directory.GroupBy(f => f.Filename?[..f.Filename.LastIndexOf('\\')]).FirstOrDefault(g => g.Key == directory.Key)?.ToList();
+
             return new AlbumData("Slskd")
             {
-                AlbumId = hash,
-                ArtistName = artist ?? "Unknown Artis",
+                AlbumId = $"/api/v0/transfers/downloads/{username}",
+                ArtistName = artist ?? "Unknown Artist",
                 AlbumName = album ?? "Unknown Album",
                 ReleaseDate = folderData.Year,
                 ReleaseDateTime = (string.IsNullOrEmpty(folderData.Year) || !int.TryParse(folderData.Year, out int yearInt) ? DateTime.MinValue : new DateTime(yearInt, 1, 1)),
                 Codec = AudioFormatHelper.GetAudioFormatFromCodec(mostCommonExtension ?? string.Empty),
                 Bitrate = bitRate ?? 0,
                 Size = totalSize,
+                CustomString = JsonConvert.SerializeObject(filesToDownload),
+                InfoUrl = $"{(string.IsNullOrEmpty(Settings.ExternalUrl) ? Settings.BaseUrl : Settings.ExternalUrl)}/searches/{searchId}",
                 Duration = totalDuration
             };
         }
 
-        private string? GetMostCommonExtension(IEnumerable<SlskdFileData> files)
+        private static string? GetMostCommonExtension(IEnumerable<SlskdFileData> files)
         {
-            List<string?> extensions = files
-                .Select(f => string.IsNullOrEmpty(f.Extension) ? Path.GetExtension(f.Filename)?.TrimStart('.').ToLowerInvariant() : f.Extension)
-                .Where(ext => !string.IsNullOrEmpty(ext))
-                .ToList();
-
-            if (!extensions.Any())
-                return null;
-
-            string? mostCommonExtension = extensions
-                .GroupBy(ext => ext)
-                .OrderByDescending(g => g.Count())
-                .Select(g => g.Key)
-                .FirstOrDefault();
-
-            _logger.Trace($"Most common extension: {mostCommonExtension}");
-            return mostCommonExtension;
+            List<string?> extensions = files.Select(f => string.IsNullOrEmpty(f.Extension) ? Path.GetExtension(f.Filename)?.TrimStart('.')
+            .ToLowerInvariant() : f.Extension).Where(ext => !string.IsNullOrEmpty(ext)).ToList();
+            return extensions.Any() ? extensions.GroupBy(ext => ext).OrderByDescending(g => g.Count()).Select(g => g.Key).FirstOrDefault() : null;
         }
 
         private static IEnumerable<JsonElement> GetResponses(JsonElement responsesElement)
@@ -131,5 +125,21 @@ namespace NzbDrone.Core.Indexers.Soulseek
             foreach (JsonElement response in responsesElement.EnumerateArray())
                 yield return response;
         }
+
+        public async Task RemoveSearch(string searchId)
+        {
+            try
+            {
+                HttpRequest request = new HttpRequestBuilder($"{Settings.BaseUrl}/api/v0/searches/{searchId}").SetHeader("X-API-KEY", Settings.ApiKey).Build();
+
+                request.Method = HttpMethod.Delete;
+                HttpResponse response = await _httpClient.ExecuteAsync(request);
+            }
+            catch (HttpException ex)
+            {
+                _logger.Error(ex, $"Failed to remove slskd search with ID: {searchId}");
+            }
+        }
+
     }
 }

--- a/Tubifarry/Indexers/Soulseek/SlskdParser.cs
+++ b/Tubifarry/Indexers/Soulseek/SlskdParser.cs
@@ -1,0 +1,135 @@
+﻿using NLog;
+using NzbDrone.Common.Instrumentation;
+using NzbDrone.Core.Parser.Model;
+using System.Text.Json;
+using Tubifarry.Core;
+
+namespace NzbDrone.Core.Indexers.Soulseek
+{
+    public class SlskdParser : IParseIndexerResponse
+    {
+        private readonly Logger _logger;
+
+        public SlskdParser() => _logger = NzbDroneLogger.GetLogger(this);
+
+
+        public IList<ReleaseInfo> ParseResponse(IndexerResponse indexerResponse)
+        {
+            List<ReleaseInfo> releases = new();
+
+            try
+            {
+                using JsonDocument jsonDoc = JsonDocument.Parse(indexerResponse.Content);
+                JsonElement root = jsonDoc.RootElement;
+
+                if (!root.TryGetProperty("searchText", out JsonElement searchTextElement) ||
+                    !root.TryGetProperty("responses", out JsonElement responsesElement))
+                {
+                    _logger.Warn("Required fields are missing in the slskd search response.");
+                    return releases;
+                }
+
+                string? searchText = searchTextElement.GetString();
+                SlskdSearchTextData searchTextData = SlskdSearchTextData.ParseSearchText(searchText ?? string.Empty);
+
+                foreach (JsonElement responseElement in GetResponses(responsesElement))
+                {
+                    if (!responseElement.TryGetProperty("fileCount", out JsonElement fileCountElement) || fileCountElement.GetInt32() == 0)
+                        continue;
+
+                    string? username = responseElement.TryGetProperty("username", out JsonElement usernameElement) ? usernameElement.GetString() : "Unknown User";
+
+                    if (!responseElement.TryGetProperty("files", out JsonElement filesElement))
+                        continue;
+
+                    List<SlskdFileData> files = SlskdFileData.GetFiles(filesElement).ToList();
+                    List<IGrouping<string, SlskdFileData>> directories = files
+                        .GroupBy(f => f.Filename?[..f.Filename.LastIndexOf('\\')] ?? "")
+                        .ToList();
+
+                    foreach (IGrouping<string, SlskdFileData>? directory in directories)
+                    {
+                        if (string.IsNullOrEmpty(directory.Key))
+                            continue;
+
+                        SlskdFolderData folderData = SlskdFolderData.ParseFolderName(directory.Key);
+                        AlbumData albumData = CreateAlbumData(directory, username ?? "Unknown Username", searchTextData, folderData);
+
+                        releases.Add(albumData.ToReleaseInfo());
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Failed to parse Slskd search response.");
+            }
+
+            return releases.OrderByDescending(r => r.Size).ToList();
+        }
+
+        private AlbumData CreateAlbumData(IGrouping<string, SlskdFileData> directory, string username, SlskdSearchTextData searchTextData, SlskdFolderData folderData)
+        {
+            string hash = $"{username} {directory.Key}".GetHashCode().ToString("X");
+
+            bool isArtistContained = !string.IsNullOrEmpty(searchTextData.Artist) && directory.Key.Contains(searchTextData.Artist, StringComparison.OrdinalIgnoreCase);
+            bool isAlbumContained = !string.IsNullOrEmpty(searchTextData.Album) && directory.Key.Contains(searchTextData.Album, StringComparison.OrdinalIgnoreCase);
+
+            string? artist = isArtistContained ? searchTextData.Artist : folderData.Artist;
+            string? album = isAlbumContained ? searchTextData.Album : folderData.Album;
+
+            artist = string.IsNullOrEmpty(artist) ? searchTextData.Artist : artist;
+            album = string.IsNullOrEmpty(album) ? searchTextData.Album : album;
+
+            string? mostCommonExtension = GetMostCommonExtension(directory);
+
+            long totalSize = directory.Sum(f => f.Size);
+            int totalDuration = directory.Sum(f => f.Length ?? 0);
+
+            int? bitRate = directory.First().BitRate;
+            if (!bitRate.HasValue && totalDuration > 0)
+                bitRate = (int)((totalSize * 8) / (totalDuration * 1000));
+
+            return new AlbumData("Slskd")
+            {
+                AlbumId = hash,
+                ArtistName = artist ?? "Unknown Artis",
+                AlbumName = album ?? "Unknown Album",
+                ReleaseDate = folderData.Year,
+                ReleaseDateTime = (string.IsNullOrEmpty(folderData.Year) || !int.TryParse(folderData.Year, out int yearInt) ? DateTime.MinValue : new DateTime(yearInt, 1, 1)),
+                Codec = AudioFormatHelper.GetAudioFormatFromCodec(mostCommonExtension ?? string.Empty),
+                Bitrate = bitRate ?? 0,
+                Size = totalSize,
+                Duration = totalDuration
+            };
+        }
+
+        private string? GetMostCommonExtension(IEnumerable<SlskdFileData> files)
+        {
+            List<string?> extensions = files
+                .Select(f => string.IsNullOrEmpty(f.Extension) ? Path.GetExtension(f.Filename)?.TrimStart('.').ToLowerInvariant() : f.Extension)
+                .Where(ext => !string.IsNullOrEmpty(ext))
+                .ToList();
+
+            if (!extensions.Any())
+                return null;
+
+            string? mostCommonExtension = extensions
+                .GroupBy(ext => ext)
+                .OrderByDescending(g => g.Count())
+                .Select(g => g.Key)
+                .FirstOrDefault();
+
+            _logger.Trace($"Most common extension: {mostCommonExtension}");
+            return mostCommonExtension;
+        }
+
+        private static IEnumerable<JsonElement> GetResponses(JsonElement responsesElement)
+        {
+            if (responsesElement.ValueKind != JsonValueKind.Array)
+                yield break;
+
+            foreach (JsonElement response in responsesElement.EnumerateArray())
+                yield return response;
+        }
+    }
+}

--- a/Tubifarry/Indexers/Soulseek/SlskdRequestGenerator.cs
+++ b/Tubifarry/Indexers/Soulseek/SlskdRequestGenerator.cs
@@ -1,0 +1,152 @@
+﻿using Newtonsoft.Json;
+using NLog;
+using NzbDrone.Common.Http;
+using NzbDrone.Common.Instrumentation;
+using NzbDrone.Core.IndexerSearch.Definitions;
+using System.Net;
+
+namespace NzbDrone.Core.Indexers.Soulseek
+{
+    internal class SlskdRequestGenerator : IIndexerRequestGenerator
+    {
+        private readonly SlskdIndexer _indexer;
+        private readonly Logger _logger;
+        private SlskdSettings Settings => _indexer.Settings;
+        private readonly IHttpClient _client;
+
+        private HttpRequest? _searchResultsRequest;
+
+        public SlskdRequestGenerator(SlskdIndexer indexer, IHttpClient client)
+        {
+            _indexer = indexer;
+            _client = client;
+            _logger = NzbDroneLogger.GetLogger(this);
+        }
+
+        public IndexerPageableRequestChain GetRecentRequests() => new();
+
+        public IndexerPageableRequestChain GetSearchRequests(AlbumSearchCriteria searchCriteria)
+        {
+            _logger.Trace($"Generating search requests for album: {searchCriteria.AlbumQuery} by artist: {searchCriteria.ArtistQuery}");
+            IndexerPageableRequestChain chain = new();
+
+            string searchQuery = $"{searchCriteria.AlbumQuery}  {searchCriteria.ArtistQuery}";
+            chain.AddTier(GetRequests(searchQuery, "album"));
+            return chain;
+        }
+
+        public IndexerPageableRequestChain GetSearchRequests(ArtistSearchCriteria searchCriteria)
+        {
+            _logger.Trace($"Generating search requests for artist: {searchCriteria.ArtistQuery}");
+            IndexerPageableRequestChain chain = new();
+
+            string searchQuery = $"  {searchCriteria.ArtistQuery}";
+            chain.AddTier(GetRequests(searchQuery, "album"));
+            return chain;
+        }
+
+        private IEnumerable<IndexerRequest> GetRequests(string searchQuery, string searchType)
+        {
+            var searchData = new
+            {
+                Id = Guid.NewGuid().ToString(),
+                Settings.FileLimit,
+                FilterResponses = true,
+                Settings.MaximumPeerQueueLength,
+                Settings.MinimumPeerUploadSpeed,
+                Settings.MinimumResponseFileCount,
+                Settings.ResponseLimit,
+                SearchText = searchQuery,
+                SearchTimeout = (int)((Settings.TimeoutInSeconds - 10) * 1000),
+            };
+
+            string jsonData = JsonConvert.SerializeObject(searchData);
+
+            _logger.Info($"Sending search request with payload: {jsonData}");
+
+            HttpRequest searchRequest = new HttpRequestBuilder($"{Settings.BaseUrl}/api/v0/searches")
+                .SetHeader("X-API-KEY", Settings.ApiKey)
+                .SetHeader("Content-Type", "application/json")
+                .Post()
+                .Build();
+
+            searchRequest.SetContent(jsonData);
+            _client.Execute(searchRequest);
+            _ = WaitOnSearchCompletionAsync(searchData.Id, TimeSpan.FromSeconds(Settings.TimeoutInSeconds)).Result;
+
+            _logger.Info($"Generated search initiation request: {searchRequest.Url}");
+
+            HttpRequest request = new HttpRequestBuilder($"{Settings.BaseUrl}/api/v0/searches/{searchData.Id}")
+                .AddQueryParam("includeResponses", true).SetHeader("X-API-KEY", Settings.ApiKey).Build();
+
+            yield return new IndexerRequest(request);
+        }
+
+        private async Task<dynamic?> WaitOnSearchCompletionAsync(string searchId, TimeSpan timeout)
+        {
+            DateTime startTime = DateTime.UtcNow;
+            string state = "InProgress";
+            int totalFilesFound = 0;
+
+            while (state == "InProgress")
+            {
+                TimeSpan elapsed = DateTime.UtcNow - startTime;
+                if (elapsed > timeout)
+                {
+                    _logger.Warn($"Search timed out after {timeout.TotalSeconds} seconds.");
+                    throw new TimeoutException("Search did not complete within the specified timeout.");
+                }
+
+                dynamic? searchStatus = await GetSearchResultsAsync(searchId);
+                state = searchStatus?.state ?? "InProgress";
+
+                int fileCount = (int)(searchStatus?.fileCount ?? 0);
+
+                if (fileCount > totalFilesFound)
+                    totalFilesFound = fileCount;
+
+                double progress = Math.Clamp(fileCount / (double)Settings.FileLimit, 0.0, 1.0);
+                double delay = CalculateQuadraticDelay(progress);
+
+                _logger.Info($"Current progress: {progress:P0}, Files found: {fileCount}, Next delay: {delay} seconds");
+                await Task.Delay(TimeSpan.FromSeconds(delay));
+
+                if (state != "InProgress")
+                    break;
+            }
+
+            _logger.Info($"Search completed with state: {state}, Total files found: {totalFilesFound}");
+
+            return await GetSearchResultsAsync(searchId);
+        }
+
+
+        private static double CalculateQuadraticDelay(double progress)
+        {
+            double a = 16;
+            double b = -16;
+            double c = 5;
+
+            double delay = a * Math.Pow(progress, 2) + b * progress + c;
+            return Math.Clamp(delay, 0.5, 5);
+        }
+
+        private async Task<dynamic?> GetSearchResultsAsync(string searchId)
+        {
+            _searchResultsRequest ??= new HttpRequestBuilder($"{Settings.BaseUrl}/api/v0/searches/{searchId}")
+                     .SetHeader("X-API-KEY", Settings.ApiKey)
+                     .Build();
+
+            HttpResponse response = await _client.ExecuteAsync(_searchResultsRequest);
+
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                _logger.Warn($"Failed to fetch search results. Status: {response.StatusCode}, Content: {response.Content}");
+                return null;
+            }
+
+            _logger.Info(response.Content);
+            return JsonConvert.DeserializeObject<dynamic>(response.Content);
+        }
+    }
+}

--- a/Tubifarry/Indexers/Soulseek/SlskdSettings.cs
+++ b/Tubifarry/Indexers/Soulseek/SlskdSettings.cs
@@ -1,0 +1,78 @@
+﻿using FluentValidation;
+using NzbDrone.Core.Annotations;
+using NzbDrone.Core.Validation;
+
+namespace NzbDrone.Core.Indexers.Soulseek
+{
+    internal class SlskdSettingsValidator : AbstractValidator<SlskdSettings>
+    {
+        public SlskdSettingsValidator()
+        {
+            RuleFor(c => c.BaseUrl)
+                .ValidRootUrl()
+                .Must(url => !url.EndsWith("/"))
+                .WithMessage("Base URL must not end with a slash ('/').");
+
+            RuleFor(c => c.ApiKey)
+                .NotEmpty()
+                .WithMessage("API Key is required.");
+
+            RuleFor(c => c.FileLimit)
+                .GreaterThanOrEqualTo(1)
+                .WithMessage("File Limit must be at least 1.");
+
+            RuleFor(c => c.MaximumPeerQueueLength)
+                .GreaterThanOrEqualTo(100)
+                .WithMessage("Maximum Peer Queue Length must be at least 100.");
+
+            RuleFor(c => c.MinimumPeerUploadSpeed)
+                .GreaterThanOrEqualTo(0)
+                .WithMessage("Minimum Peer Upload Speed must be a non-negative value.");
+
+            RuleFor(c => c.MinimumResponseFileCount)
+                .GreaterThanOrEqualTo(1)
+                .WithMessage("Minimum Response File Count must be at least 1.");
+
+            RuleFor(c => c.ResponseLimit)
+                .GreaterThanOrEqualTo(1)
+                .WithMessage("Response Limit must be at least 1.");
+
+            RuleFor(c => c.TimeoutInSeconds)
+                .GreaterThanOrEqualTo(15.0)
+                .WithMessage("Timeout must be at least 15 seconds.");
+        }
+    }
+
+    public class SlskdSettings : IIndexerSettings
+    {
+        private static readonly SlskdSettingsValidator Validator = new();
+
+        [FieldDefinition(0, Label = "URL", Type = FieldType.Url, Placeholder = "http://localhost:5030", HelpText = "The URL of your Slskd instance.")]
+        public string BaseUrl { get; set; } = "http://localhost:5030";
+
+        [FieldDefinition(1, Label = "API Key", Type = FieldType.Textbox, Privacy = PrivacyLevel.ApiKey, HelpText = "The API key for your Slskd instance. You can find or set this in the Slskd's settings under 'Options'.", Placeholder = "Enter your API key")]
+        public string ApiKey { get; set; } = string.Empty;
+
+        [FieldDefinition(2, Type = FieldType.Number, Label = "Early Download Limit", Unit = "days", HelpText = "Time before release date Lidarr will download from this indexer, empty is no limit", Advanced = true)]
+        public int? EarlyReleaseLimit { get; set; } = null;
+
+        [FieldDefinition(3, Type = FieldType.Number, Label = "File Limit", HelpText = "Maximum number of files to return in a search response.", Advanced = true)]
+        public int FileLimit { get; set; } = 10000;
+
+        [FieldDefinition(4, Type = FieldType.Number, Label = "Maximum Peer Queue Length", HelpText = "Maximum number of queued requests allowed per peer.", Advanced = true)]
+        public int MaximumPeerQueueLength { get; set; } = 1000000;
+
+        [FieldDefinition(5, Type = FieldType.Number, Label = "Minimum Peer Upload Speed", Unit = "KB/s", HelpText = "Minimum upload speed required for peers (in KB/s).", Advanced = true)]
+        public int MinimumPeerUploadSpeed { get; set; } = 0;
+
+        [FieldDefinition(6, Type = FieldType.Number, Label = "Minimum Response File Count", HelpText = "Minimum number of files required in a search response.", Advanced = true)]
+        public int MinimumResponseFileCount { get; set; } = 1;
+
+        [FieldDefinition(7, Type = FieldType.Number, Label = "Response Limit", HelpText = "Maximum number of search responses to return.", Advanced = true)]
+        public int ResponseLimit { get; set; } = 100;
+
+        [FieldDefinition(8, Type = FieldType.Number, Label = "Timeout", Unit = "seconds", HelpText = "Timeout for search requests in seconds.", Advanced = true)]
+        public double TimeoutInSeconds { get; set; } = 15;
+        public NzbDroneValidationResult Validate() => new(Validator.Validate(this));
+    }
+}

--- a/Tubifarry/Indexers/Soulseek/SlskdSettings.cs
+++ b/Tubifarry/Indexers/Soulseek/SlskdSettings.cs
@@ -8,38 +8,51 @@ namespace NzbDrone.Core.Indexers.Soulseek
     {
         public SlskdSettingsValidator()
         {
+            // Base URL validation
             RuleFor(c => c.BaseUrl)
                 .ValidRootUrl()
                 .Must(url => !url.EndsWith("/"))
                 .WithMessage("Base URL must not end with a slash ('/').");
 
+            // External URL validation (only if not empty)
+            RuleFor(c => c.ExternalUrl)
+                .Must(url => string.IsNullOrEmpty(url) || (Uri.IsWellFormedUriString(url, UriKind.Absolute) && !url.EndsWith("/")))
+                .WithMessage("External URL must be a valid URL and must not end with a slash ('/').");
+
+            // API Key validation
             RuleFor(c => c.ApiKey)
                 .NotEmpty()
                 .WithMessage("API Key is required.");
 
+            // File Limit validation
             RuleFor(c => c.FileLimit)
                 .GreaterThanOrEqualTo(1)
                 .WithMessage("File Limit must be at least 1.");
 
+            // Maximum Peer Queue Length validation
             RuleFor(c => c.MaximumPeerQueueLength)
                 .GreaterThanOrEqualTo(100)
                 .WithMessage("Maximum Peer Queue Length must be at least 100.");
 
+            // Minimum Peer Upload Speed validation
             RuleFor(c => c.MinimumPeerUploadSpeed)
                 .GreaterThanOrEqualTo(0)
                 .WithMessage("Minimum Peer Upload Speed must be a non-negative value.");
 
+            // Minimum Response File Count validation
             RuleFor(c => c.MinimumResponseFileCount)
                 .GreaterThanOrEqualTo(1)
                 .WithMessage("Minimum Response File Count must be at least 1.");
 
+            // Response Limit validation
             RuleFor(c => c.ResponseLimit)
                 .GreaterThanOrEqualTo(1)
                 .WithMessage("Response Limit must be at least 1.");
 
+            // Timeout validation
             RuleFor(c => c.TimeoutInSeconds)
-                .GreaterThanOrEqualTo(15.0)
-                .WithMessage("Timeout must be at least 15 seconds.");
+                .GreaterThanOrEqualTo(5.0)
+                .WithMessage("Timeout must be at least 5 seconds.");
         }
     }
 
@@ -50,29 +63,33 @@ namespace NzbDrone.Core.Indexers.Soulseek
         [FieldDefinition(0, Label = "URL", Type = FieldType.Url, Placeholder = "http://localhost:5030", HelpText = "The URL of your Slskd instance.")]
         public string BaseUrl { get; set; } = "http://localhost:5030";
 
-        [FieldDefinition(1, Label = "API Key", Type = FieldType.Textbox, Privacy = PrivacyLevel.ApiKey, HelpText = "The API key for your Slskd instance. You can find or set this in the Slskd's settings under 'Options'.", Placeholder = "Enter your API key")]
+        [FieldDefinition(1, Label = "External URL", Type = FieldType.Url, Placeholder = "https://slskd.example.com", HelpText = "An optional external URL for additional resources or documentation.", Advanced = true)]
+        public string? ExternalUrl { get; set; } = string.Empty;
+
+        [FieldDefinition(2, Label = "API Key", Type = FieldType.Textbox, Privacy = PrivacyLevel.ApiKey, HelpText = "The API key for your Slskd instance. You can find or set this in the Slskd's settings under 'Options'.", Placeholder = "Enter your API key")]
         public string ApiKey { get; set; } = string.Empty;
 
-        [FieldDefinition(2, Type = FieldType.Number, Label = "Early Download Limit", Unit = "days", HelpText = "Time before release date Lidarr will download from this indexer, empty is no limit", Advanced = true)]
+        [FieldDefinition(3, Type = FieldType.Number, Label = "Early Download Limit", Unit = "days", HelpText = "Time before release date Lidarr will download from this indexer, empty is no limit", Advanced = true)]
         public int? EarlyReleaseLimit { get; set; } = null;
 
-        [FieldDefinition(3, Type = FieldType.Number, Label = "File Limit", HelpText = "Maximum number of files to return in a search response.", Advanced = true)]
+        [FieldDefinition(4, Type = FieldType.Number, Label = "File Limit", HelpText = "Maximum number of files to return in a search response.", Advanced = true)]
         public int FileLimit { get; set; } = 10000;
 
-        [FieldDefinition(4, Type = FieldType.Number, Label = "Maximum Peer Queue Length", HelpText = "Maximum number of queued requests allowed per peer.", Advanced = true)]
+        [FieldDefinition(5, Type = FieldType.Number, Label = "Maximum Peer Queue Length", HelpText = "Maximum number of queued requests allowed per peer.", Advanced = true)]
         public int MaximumPeerQueueLength { get; set; } = 1000000;
 
-        [FieldDefinition(5, Type = FieldType.Number, Label = "Minimum Peer Upload Speed", Unit = "KB/s", HelpText = "Minimum upload speed required for peers (in KB/s).", Advanced = true)]
+        [FieldDefinition(6, Type = FieldType.Number, Label = "Minimum Peer Upload Speed", Unit = "KB/s", HelpText = "Minimum upload speed required for peers (in KB/s).", Advanced = true)]
         public int MinimumPeerUploadSpeed { get; set; } = 0;
 
-        [FieldDefinition(6, Type = FieldType.Number, Label = "Minimum Response File Count", HelpText = "Minimum number of files required in a search response.", Advanced = true)]
+        [FieldDefinition(7, Type = FieldType.Number, Label = "Minimum Response File Count", HelpText = "Minimum number of files required in a search response.", Advanced = true)]
         public int MinimumResponseFileCount { get; set; } = 1;
 
-        [FieldDefinition(7, Type = FieldType.Number, Label = "Response Limit", HelpText = "Maximum number of search responses to return.", Advanced = true)]
+        [FieldDefinition(8, Type = FieldType.Number, Label = "Response Limit", HelpText = "Maximum number of search responses to return.", Advanced = true)]
         public int ResponseLimit { get; set; } = 100;
 
-        [FieldDefinition(8, Type = FieldType.Number, Label = "Timeout", Unit = "seconds", HelpText = "Timeout for search requests in seconds.", Advanced = true)]
+        [FieldDefinition(9, Type = FieldType.Number, Label = "Timeout", Unit = "seconds", HelpText = "Timeout for search requests in seconds.", Advanced = true)]
         public double TimeoutInSeconds { get; set; } = 15;
+
         public NzbDroneValidationResult Validate() => new(Validator.Validate(this));
     }
 }

--- a/Tubifarry/Indexers/Soulseek/SlskdSettings.cs
+++ b/Tubifarry/Indexers/Soulseek/SlskdSettings.cs
@@ -51,8 +51,13 @@ namespace NzbDrone.Core.Indexers.Soulseek
 
             // Timeout validation
             RuleFor(c => c.TimeoutInSeconds)
-                .GreaterThanOrEqualTo(5.0)
-                .WithMessage("Timeout must be at least 5 seconds.");
+                .GreaterThanOrEqualTo(2.0)
+                .WithMessage("Timeout must be at least 2 seconds.");
+
+            // Include File Extensions validation
+            RuleFor(c => c.IncludeFileExtensions)
+                .Must(extensions => extensions == null || extensions.All(ext => !ext.Contains(".")))
+                .WithMessage("File extensions must not contain a dot ('.').");
         }
     }
 
@@ -69,26 +74,32 @@ namespace NzbDrone.Core.Indexers.Soulseek
         [FieldDefinition(2, Label = "API Key", Type = FieldType.Textbox, Privacy = PrivacyLevel.ApiKey, HelpText = "The API key for your Slskd instance. You can find or set this in the Slskd's settings under 'Options'.", Placeholder = "Enter your API key")]
         public string ApiKey { get; set; } = string.Empty;
 
-        [FieldDefinition(3, Type = FieldType.Number, Label = "Early Download Limit", Unit = "days", HelpText = "Time before release date Lidarr will download from this indexer, empty is no limit", Advanced = true)]
+        [FieldDefinition(3, Type = FieldType.Checkbox, Label = "Include Only Audio Files", HelpText = "When enabled, only files with audio extensions will be included in search results. Disabling this option allows all file types.", Advanced = false)]
+        public bool OnlyAudioFiles { get; set; } = true;
+
+        [FieldDefinition(4, Type = FieldType.ArtistTag, Label = "Include File Extensions", HelpText = "Specify file extensions to include when 'Include Only Audio Files' is enabled. This setting has no effect if 'Include Only Audio Files' is disabled.", Advanced = true)]
+        public IEnumerable<string> IncludeFileExtensions { get; set; } = Array.Empty<string>();
+
+        [FieldDefinition(5, Type = FieldType.Number, Label = "Early Download Limit", Unit = "days", HelpText = "Time before release date Lidarr will download from this indexer, empty is no limit", Advanced = true)]
         public int? EarlyReleaseLimit { get; set; } = null;
 
-        [FieldDefinition(4, Type = FieldType.Number, Label = "File Limit", HelpText = "Maximum number of files to return in a search response.", Advanced = true)]
+        [FieldDefinition(6, Type = FieldType.Number, Label = "File Limit", HelpText = "Maximum number of files to return in a search response.", Advanced = true)]
         public int FileLimit { get; set; } = 10000;
 
-        [FieldDefinition(5, Type = FieldType.Number, Label = "Maximum Peer Queue Length", HelpText = "Maximum number of queued requests allowed per peer.", Advanced = true)]
+        [FieldDefinition(7, Type = FieldType.Number, Label = "Maximum Peer Queue Length", HelpText = "Maximum number of queued requests allowed per peer.", Advanced = true)]
         public int MaximumPeerQueueLength { get; set; } = 1000000;
 
-        [FieldDefinition(6, Type = FieldType.Number, Label = "Minimum Peer Upload Speed", Unit = "KB/s", HelpText = "Minimum upload speed required for peers (in KB/s).", Advanced = true)]
+        [FieldDefinition(8, Type = FieldType.Number, Label = "Minimum Peer Upload Speed", Unit = "KB/s", HelpText = "Minimum upload speed required for peers (in KB/s).", Advanced = true)]
         public int MinimumPeerUploadSpeed { get; set; } = 0;
 
-        [FieldDefinition(7, Type = FieldType.Number, Label = "Minimum Response File Count", HelpText = "Minimum number of files required in a search response.", Advanced = true)]
+        [FieldDefinition(9, Type = FieldType.Number, Label = "Minimum Response File Count", HelpText = "Minimum number of files required in a search response.", Advanced = true)]
         public int MinimumResponseFileCount { get; set; } = 1;
 
-        [FieldDefinition(8, Type = FieldType.Number, Label = "Response Limit", HelpText = "Maximum number of search responses to return.", Advanced = true)]
+        [FieldDefinition(10, Type = FieldType.Number, Label = "Response Limit", HelpText = "Maximum number of search responses to return.", Advanced = true)]
         public int ResponseLimit { get; set; } = 100;
 
-        [FieldDefinition(9, Type = FieldType.Number, Label = "Timeout", Unit = "seconds", HelpText = "Timeout for search requests in seconds.", Advanced = true)]
-        public double TimeoutInSeconds { get; set; } = 15;
+        [FieldDefinition(11, Type = FieldType.Number, Label = "Timeout", Unit = "seconds", HelpText = "Timeout for search requests in seconds.", Advanced = true)]
+        public double TimeoutInSeconds { get; set; } = 5;
 
         public NzbDroneValidationResult Validate() => new(Validator.Validate(this));
     }

--- a/Tubifarry/Indexers/Soulseek/SoulseekModels.cs
+++ b/Tubifarry/Indexers/Soulseek/SoulseekModels.cs
@@ -1,0 +1,90 @@
+﻿using System.Text.Json;
+
+namespace NzbDrone.Core.Indexers.Soulseek
+{
+    public class SlskdFileData
+    {
+        public string? Filename { get; }
+        public int? BitRate { get; }
+        public int? BitDepth { get; }
+        public long Size { get; }
+        public int? Length { get; }
+        public string? Extension { get; }
+
+        public SlskdFileData(string? filename, int? bitRate, int? bitDepth, long size, int? length, string? extension)
+        {
+            Filename = filename;
+            BitRate = bitRate;
+            BitDepth = bitDepth;
+            Size = size;
+            Length = length;
+            Extension = extension;
+        }
+
+        public static IEnumerable<SlskdFileData> GetFiles(JsonElement filesElement)
+        {
+            if (filesElement.ValueKind != JsonValueKind.Array)
+                yield break;
+
+            foreach (JsonElement file in filesElement.EnumerateArray())
+            {
+                string? filename = file.GetProperty("filename").GetString();
+                int? bitRate = file.TryGetProperty("bitRate", out JsonElement bitRateElement) ? bitRateElement.GetInt32() : null;
+                int? bitDepth = file.TryGetProperty("bitDepth", out JsonElement bitDepthElement) ? bitDepthElement.GetInt32() : null;
+                long size = file.GetProperty("size").GetInt64();
+                int? length = file.TryGetProperty("length", out JsonElement lengthElement) ? lengthElement.GetInt32() : null;
+
+                string? extension = file.TryGetProperty("extension", out JsonElement extensionElement)
+                    ? extensionElement.GetString()
+                    : Path.GetExtension(filename)?.TrimStart('.').ToLowerInvariant();
+
+                yield return new SlskdFileData(filename, bitRate, bitDepth, size, length, extension);
+            }
+        }
+    }
+    public class SlskdFolderData
+    {
+        public string Artist { get; }
+        public string Album { get; }
+        public string Year { get; }
+
+        public SlskdFolderData(string artist, string album, string year)
+        {
+            Artist = artist;
+            Album = album;
+            Year = year;
+        }
+
+        public static SlskdFolderData ParseFolderName(string folderName)
+        {
+            string[] parts = folderName.Split(new[] { '-', ' ', '\\', '/' }, StringSplitOptions.RemoveEmptyEntries);
+
+            string artist = parts.Length > 0 ? parts[0].Replace("_", " ") : "Unknown Artist";
+            string album = parts.Length > 1 ? parts[1].Replace("_", " ") : "Unknown Album";
+            string year = parts.FirstOrDefault(p => p.Length == 4 && p.All(char.IsDigit)) ?? string.Empty;
+
+            return new SlskdFolderData(artist, album, year);
+        }
+    }
+
+    public class SlskdSearchTextData
+    {
+        public string? Artist { get; }
+        public string? Album { get; }
+
+        public SlskdSearchTextData(string? artist, string? album)
+        {
+            Artist = artist;
+            Album = album;
+        }
+
+        public static SlskdSearchTextData ParseSearchText(string searchText)
+        {
+            string[] parts = searchText.Split(new[] { "  " }, StringSplitOptions.RemoveEmptyEntries);
+            string? album = parts.Length > 0 ? parts[0].Trim() : null;
+            string? artist = parts.Length > 1 ? parts[1].Trim() : null;
+            return new SlskdSearchTextData(artist, album);
+        }
+    }
+}
+

--- a/Tubifarry/Indexers/Soulseek/SoulseekModels.cs
+++ b/Tubifarry/Indexers/Soulseek/SoulseekModels.cs
@@ -2,25 +2,8 @@
 
 namespace NzbDrone.Core.Indexers.Soulseek
 {
-    public class SlskdFileData
+    public record SlskdFileData(string? Filename, int? BitRate, int? BitDepth, long Size, int? Length, string? Extension, int? SampleRate, int Code, bool IsLocked)
     {
-        public string? Filename { get; }
-        public int? BitRate { get; }
-        public int? BitDepth { get; }
-        public long Size { get; }
-        public int? Length { get; }
-        public string? Extension { get; }
-
-        public SlskdFileData(string? filename, int? bitRate, int? bitDepth, long size, int? length, string? extension)
-        {
-            Filename = filename;
-            BitRate = bitRate;
-            BitDepth = bitDepth;
-            Size = size;
-            Length = length;
-            Extension = extension;
-        }
-
         public static IEnumerable<SlskdFileData> GetFiles(JsonElement filesElement)
         {
             if (filesElement.ValueKind != JsonValueKind.Array)
@@ -28,62 +11,44 @@ namespace NzbDrone.Core.Indexers.Soulseek
 
             foreach (JsonElement file in filesElement.EnumerateArray())
             {
-                string? filename = file.GetProperty("filename").GetString();
-                int? bitRate = file.TryGetProperty("bitRate", out JsonElement bitRateElement) ? bitRateElement.GetInt32() : null;
-                int? bitDepth = file.TryGetProperty("bitDepth", out JsonElement bitDepthElement) ? bitDepthElement.GetInt32() : null;
-                long size = file.GetProperty("size").GetInt64();
-                int? length = file.TryGetProperty("length", out JsonElement lengthElement) ? lengthElement.GetInt32() : null;
-
-                string? extension = file.TryGetProperty("extension", out JsonElement extensionElement)
-                    ? extensionElement.GetString()
-                    : Path.GetExtension(filename)?.TrimStart('.').ToLowerInvariant();
-
-                yield return new SlskdFileData(filename, bitRate, bitDepth, size, length, extension);
+                yield return new SlskdFileData(
+                    Filename: file.GetProperty("filename").GetString(),
+                    BitRate: file.TryGetProperty("bitRate", out JsonElement bitRateElement) ? bitRateElement.GetInt32() : null,
+                    BitDepth: file.TryGetProperty("bitDepth", out JsonElement bitDepthElement) ? bitDepthElement.GetInt32() : null,
+                    Size: file.GetProperty("size").GetInt64(),
+                    Length: file.TryGetProperty("length", out JsonElement lengthElement) ? lengthElement.GetInt32() : null,
+                    Extension: file.TryGetProperty("extension", out JsonElement extensionElement) ? extensionElement.GetString() : Path.GetExtension(file.GetProperty("filename").GetString())?.TrimStart('.').ToLowerInvariant(),
+                    SampleRate: file.TryGetProperty("sampleRate", out JsonElement sampleRateElement) ? sampleRateElement.GetInt32() : null,
+                    Code: file.TryGetProperty("code", out JsonElement codeElement) ? codeElement.GetInt32() : 1,
+                    IsLocked: file.TryGetProperty("isLocked", out JsonElement isLockedElement) && isLockedElement.GetBoolean()
+                );
             }
         }
     }
-    public class SlskdFolderData
+
+    public record SlskdFolderData(string Path, string Artist, string Album, string Year)
     {
-        public string Artist { get; }
-        public string Album { get; }
-        public string Year { get; }
-
-        public SlskdFolderData(string artist, string album, string year)
-        {
-            Artist = artist;
-            Album = album;
-            Year = year;
-        }
-
         public static SlskdFolderData ParseFolderName(string folderName)
         {
             string[] parts = folderName.Split(new[] { '-', ' ', '\\', '/' }, StringSplitOptions.RemoveEmptyEntries);
-
-            string artist = parts.Length > 0 ? parts[0].Replace("_", " ") : "Unknown Artist";
-            string album = parts.Length > 1 ? parts[1].Replace("_", " ") : "Unknown Album";
-            string year = parts.FirstOrDefault(p => p.Length == 4 && p.All(char.IsDigit)) ?? string.Empty;
-
-            return new SlskdFolderData(artist, album, year);
+            return new SlskdFolderData(
+                Path: folderName,
+                Artist: parts.Length > 0 ? parts[0].Replace("_", " ") : "Unknown Artist",
+                Album: parts.Length > 1 ? parts[1].Replace("_", " ") : "Unknown Album",
+                Year: parts.FirstOrDefault(p => p.Length == 4 && p.All(char.IsDigit)) ?? string.Empty
+            );
         }
     }
 
-    public class SlskdSearchTextData
+    public record SlskdSearchTextData(string? Artist, string? Album)
     {
-        public string? Artist { get; }
-        public string? Album { get; }
-
-        public SlskdSearchTextData(string? artist, string? album)
-        {
-            Artist = artist;
-            Album = album;
-        }
-
         public static SlskdSearchTextData ParseSearchText(string searchText)
         {
             string[] parts = searchText.Split(new[] { "  " }, StringSplitOptions.RemoveEmptyEntries);
-            string? album = parts.Length > 0 ? parts[0].Trim() : null;
-            string? artist = parts.Length > 1 ? parts[1].Trim() : null;
-            return new SlskdSearchTextData(artist, album);
+            return new SlskdSearchTextData(
+                Artist: parts.Length > 1 ? parts[1].Trim() : null,
+                Album: parts.Length > 0 ? parts[0].Trim() : null
+            );
         }
     }
 }

--- a/Tubifarry/Indexers/Soulseek/SoulseekModels.cs
+++ b/Tubifarry/Indexers/Soulseek/SoulseekModels.cs
@@ -1,23 +1,32 @@
-﻿using System.Text.Json;
+﻿using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Tubifarry.Core;
 
 namespace NzbDrone.Core.Indexers.Soulseek
 {
     public record SlskdFileData(string? Filename, int? BitRate, int? BitDepth, long Size, int? Length, string? Extension, int? SampleRate, int Code, bool IsLocked)
     {
-        public static IEnumerable<SlskdFileData> GetFiles(JsonElement filesElement)
+        public static IEnumerable<SlskdFileData> GetFiles(JsonElement filesElement, bool onlyIncludeAudio = false, IEnumerable<string>? includedFileExtensions = null)
         {
             if (filesElement.ValueKind != JsonValueKind.Array)
                 yield break;
 
             foreach (JsonElement file in filesElement.EnumerateArray())
             {
+                string? filename = file.GetProperty("filename").GetString();
+                string? extension = (!file.TryGetProperty("extension", out JsonElement extensionElement) || string.IsNullOrWhiteSpace(extensionElement.GetString())) ? Path.GetExtension(filename) : extensionElement.GetString();
+
+                if (onlyIncludeAudio && AudioFormatHelper.GetAudioCodecFromExtension(extension ?? "") == AudioFormat.Unknown && !(includedFileExtensions?.Contains(null, StringComparer.OrdinalIgnoreCase) ?? false))
+                    continue;
+
                 yield return new SlskdFileData(
-                    Filename: file.GetProperty("filename").GetString(),
+                    Filename: filename,
                     BitRate: file.TryGetProperty("bitRate", out JsonElement bitRateElement) ? bitRateElement.GetInt32() : null,
                     BitDepth: file.TryGetProperty("bitDepth", out JsonElement bitDepthElement) ? bitDepthElement.GetInt32() : null,
                     Size: file.GetProperty("size").GetInt64(),
                     Length: file.TryGetProperty("length", out JsonElement lengthElement) ? lengthElement.GetInt32() : null,
-                    Extension: file.TryGetProperty("extension", out JsonElement extensionElement) ? extensionElement.GetString() : Path.GetExtension(file.GetProperty("filename").GetString())?.TrimStart('.').ToLowerInvariant(),
+                    Extension: extension,
                     SampleRate: file.TryGetProperty("sampleRate", out JsonElement sampleRateElement) ? sampleRateElement.GetInt32() : null,
                     Code: file.TryGetProperty("code", out JsonElement codeElement) ? codeElement.GetInt32() : 1,
                     IsLocked: file.TryGetProperty("isLocked", out JsonElement isLockedElement) && isLockedElement.GetBoolean()
@@ -26,30 +35,85 @@ namespace NzbDrone.Core.Indexers.Soulseek
         }
     }
 
-    public record SlskdFolderData(string Path, string Artist, string Album, string Year)
+
+    public record SlskdFolderData(string Path, string Artist, string Album, string Year, string Username, bool HasFreeUploadSlot, long UploadSpeed, int LockedFileCount, List<string> LockedFiles)
     {
+        private static readonly Regex ArtistAlbumYearPattern = new(
+            @"^(?<artist>.+?)\s*-\s*(?<album>.+?)\s*(\((?<year>\d{4})\))?\s*(\[.*\])?$",
+            RegexOptions.IgnoreCase); // Matches: Artist - Album (Year) [Metadata]
+
+        private static readonly Regex YearArtistAlbumPattern = new(
+            @"^(?<year>\d{4})\s*-\s*(?<artist>.+?)\s*-\s*(?<album>.+?)$",
+            RegexOptions.IgnoreCase); // Matches: Year - Artist - Album
+
+        private static readonly Regex AlbumYearPattern = new(
+            @"^(?<album>.+?)\s*(\((?<year>\d{4})\))?\s*(\[.*\])?$",
+            RegexOptions.IgnoreCase); // Matches: Album (Year) [Metadata]
+
         public static SlskdFolderData ParseFolderName(string folderName)
         {
-            string[] parts = folderName.Split(new[] { '-', ' ', '\\', '/' }, StringSplitOptions.RemoveEmptyEntries);
+            string folder = System.IO.Path.GetFileName(folderName);
+
+            Match? match = TryMatchRegex(folder, ArtistAlbumYearPattern) ?? TryMatchRegex(folder, YearArtistAlbumPattern) ?? TryMatchRegex(folder, AlbumYearPattern);
+
+            string artist = match?.Groups["artist"].Value.Trim() ?? GetFallbackArtist(folderName, folder);
+            string album = match?.Groups["album"].Value.Trim() ?? folder.Replace("_", " ").Trim();
+            string year = match?.Groups["year"].Value.Trim() ?? string.Empty;
+
             return new SlskdFolderData(
                 Path: folderName,
-                Artist: parts.Length > 0 ? parts[0].Replace("_", " ") : "Unknown Artist",
-                Album: parts.Length > 1 ? parts[1].Replace("_", " ") : "Unknown Album",
-                Year: parts.FirstOrDefault(p => p.Length == 4 && p.All(char.IsDigit)) ?? string.Empty
+                Artist: artist,
+                Album: album,
+                Year: year,
+                Username: string.Empty,
+                HasFreeUploadSlot: false,
+                UploadSpeed: 0,
+                LockedFileCount: 0,
+                LockedFiles: new List<string>()
             );
+        }
+
+        private static Match? TryMatchRegex(string input, Regex regex)
+        {
+            Match match = regex.Match(input);
+            return match.Success ? match : null;
+        }
+
+        private static string GetFallbackArtist(string folderName, string folder)
+        {
+            string[] folders = folderName.Split(new[] { '\\', '/' }, StringSplitOptions.RemoveEmptyEntries);
+            if (folders.Length >= 2)
+                return folders[^2].Replace("_", " ").Trim();
+            return folder;
+        }
+
+        public SlskdFolderData FillWithSlskdData(JsonElement jsonElement) => this with
+        {
+            Username = jsonElement.GetProperty("username").GetString() ?? string.Empty,
+            HasFreeUploadSlot = jsonElement.GetProperty("hasFreeUploadSlot").GetBoolean(),
+            UploadSpeed = jsonElement.GetProperty("uploadSpeed").GetInt64(),
+            LockedFileCount = jsonElement.GetProperty("lockedFileCount").GetInt32(),
+            LockedFiles = jsonElement.GetProperty("lockedFiles").EnumerateArray()
+                .Select(file => file.GetProperty("filename").GetString() ?? string.Empty).ToList()
+        };
+
+        public int CalculatePriority()
+        {
+            if (LockedFileCount > 0)
+                return 0;
+
+            double uploadSpeedPriority = Math.Log(UploadSpeed + 1) * 100;
+            double freeSlotPenalty = HasFreeUploadSlot ? 0 : -200;
+            return (int)Math.Clamp(uploadSpeedPriority + freeSlotPenalty, 0, 1000);
         }
     }
 
-    public record SlskdSearchTextData(string? Artist, string? Album)
+    public record SlskdSearchData(string? Artist, string? Album)
     {
-        public static SlskdSearchTextData ParseSearchText(string searchText)
-        {
-            string[] parts = searchText.Split(new[] { "  " }, StringSplitOptions.RemoveEmptyEntries);
-            return new SlskdSearchTextData(
-                Artist: parts.Length > 1 ? parts[1].Trim() : null,
-                Album: parts.Length > 0 ? parts[0].Trim() : null
-            );
-        }
+        public static SlskdSearchData ParseSearchText(IndexerRequest request) => new(
+            Artist: Encoding.UTF8.GetString(Convert.FromBase64String(request.HttpRequest.Headers["X-ARTIST"] ?? "")),
+            Album: Encoding.UTF8.GetString(Convert.FromBase64String(request.HttpRequest.Headers["X-ALBUM"] ?? ""))
+        );
     }
 }
 

--- a/Tubifarry/Indexers/Spotify/SpotifyRequestGenerator.cs
+++ b/Tubifarry/Indexers/Spotify/SpotifyRequestGenerator.cs
@@ -30,11 +30,8 @@ namespace NzbDrone.Core.Indexers.Spotify
 
         public IndexerPageableRequestChain GetRecentRequests()
         {
-            _logger.Debug("Generating requests for recent releases.");
             IndexerPageableRequestChain pageableRequests = new();
-
             pageableRequests.Add(GetRecentReleaseRequests());
-
             return pageableRequests;
         }
 
@@ -47,7 +44,7 @@ namespace NzbDrone.Core.Indexers.Spotify
             IndexerRequest req = new(url, HttpAccept.Json);
             req.HttpRequest.Headers.Add("Authorization", $"Bearer {_token}");
 
-            _logger.Debug($"Created request for recent releases: {url}");
+            _logger.Trace($"Created request for recent releases: {url}");
             yield return req;
         }
 
@@ -56,7 +53,6 @@ namespace NzbDrone.Core.Indexers.Spotify
             _logger.Debug($"Generating search requests for album: {searchCriteria.AlbumQuery} by artist: {searchCriteria.ArtistQuery}");
             IndexerPageableRequestChain chain = new();
 
-            // Construct the search query to include both album and artist
             string searchQuery = $"album:{searchCriteria.AlbumQuery} artist:{searchCriteria.ArtistQuery}";
             chain.AddTier(GetRequests(searchQuery, "album"));
 
@@ -68,7 +64,6 @@ namespace NzbDrone.Core.Indexers.Spotify
             _logger.Debug($"Generating search requests for artist: {searchCriteria.ArtistQuery}");
             IndexerPageableRequestChain chain = new();
 
-            // Construct the search query for the artist
             string searchQuery = $"artist:{searchCriteria.ArtistQuery}";
             chain.AddTier(GetRequests(searchQuery, "album"));
 
@@ -86,14 +81,12 @@ namespace NzbDrone.Core.Indexers.Spotify
             for (int page = 0; page < MaxPages; page++)
             {
                 int offset = page * PageSize;
-
-                // Build the URL with the formatted query
                 string url = $"https://api.spotify.com/v1/search?q={formattedQuery}&type={searchType}&limit={PageSize}&offset={offset}";
 
                 IndexerRequest req = new(url, HttpAccept.Json);
                 req.HttpRequest.Headers.Add("Authorization", $"Bearer {_token}");
 
-                _logger.Debug($"Created search request for query '{searchQuery}' (page {page + 1}): {url}");
+                _logger.Trace($"Created search request for query '{searchQuery}' (page {page + 1}): {url}");
                 yield return req;
             }
         }
@@ -115,7 +108,7 @@ namespace NzbDrone.Core.Indexers.Spotify
             {
                 try
                 {
-                    _logger.Debug("Attempting to create a new Spotify token.");
+                    _logger.Trace("Attempting to create a new Spotify token.");
                     HttpGet getter = new(new(HttpMethod.Get, "https://open.spotify.com/get_access_token?reason=transport&productType=web_player"));
                     _token = await (await getter.LoadResponseAsync()).Content.ReadAsStringAsync(token);
                     JsonElement dynamicObject = JsonSerializer.Deserialize<JsonElement>(_token)!;
@@ -123,7 +116,7 @@ namespace NzbDrone.Core.Indexers.Spotify
                     if (_token == null)
                         return false;
                     _tokenExpiry = DateTime.Now.AddMinutes(59);
-                    _logger.Debug("Successfully created a new Spotify token.");
+                    _logger.Trace("Successfully created a new Spotify token.");
 
                 }
                 catch (Exception ex)

--- a/Tubifarry/Indexers/Spotify/SpotifyToYoutubeParser.cs
+++ b/Tubifarry/Indexers/Spotify/SpotifyToYoutubeParser.cs
@@ -115,13 +115,13 @@ namespace NzbDrone.Core.Indexers.Spotify
             requestContainer.Task.Wait();
         }
 
-        private static AlbumData ExtractAlbumInfo(JsonElement album) => new()
+        private static AlbumData ExtractAlbumInfo(JsonElement album) => new("Tubifarry")
         {
             AlbumId = album.TryGetProperty("id", out JsonElement idProp) ? idProp.GetString() ?? "UnknownAlbumId" : "UnknownAlbumId",
             AlbumName = album.TryGetProperty("name", out JsonElement nameProp) ? nameProp.GetString() ?? "UnknownAlbum" : "UnknownAlbum",
             ArtistName = album.TryGetProperty("artists", out JsonElement artistsProp) && artistsProp.GetArrayLength() > 0
                     ? artistsProp[0].GetProperty("name").GetString() ?? "UnknownArtist" : "UnknownArtist",
-            SpotifyUrl = album.TryGetProperty("external_urls", out JsonElement externalUrlsProp)
+            InfoUrl = album.TryGetProperty("external_urls", out JsonElement externalUrlsProp)
                     ? externalUrlsProp.GetProperty("spotify").GetString() ?? string.Empty : string.Empty,
             ReleaseDate = album.TryGetProperty("release_date", out JsonElement releaseDateProp) ? releaseDateProp.GetString() ?? "0000-01-01" : "0000-01-01",
             ReleaseDatePrecision = album.TryGetProperty("release_date_precision", out JsonElement releaseDatePrecisionProp)

--- a/Tubifarry/Indexers/Spotify/SpotifyToYoutubeParser.cs
+++ b/Tubifarry/Indexers/Spotify/SpotifyToYoutubeParser.cs
@@ -128,7 +128,7 @@ namespace NzbDrone.Core.Indexers.Spotify
                     ? releaseDatePrecisionProp.GetString() ?? "day" : "day",
             TotalTracks = album.TryGetProperty("total_tracks", out JsonElement totalTracksProp) ? totalTracksProp.GetInt32() : 0,
             ExplicitContent = album.TryGetProperty("explicit", out JsonElement explicitProp) && explicitProp.GetBoolean(),
-            CoverUrl = album.TryGetProperty("images", out JsonElement imagesProp) && imagesProp.GetArrayLength() > 0
+            CustomString = album.TryGetProperty("images", out JsonElement imagesProp) && imagesProp.GetArrayLength() > 0
                     ? imagesProp[0].GetProperty("url").GetString() ?? string.Empty : string.Empty,
             CoverResolution = album.TryGetProperty("images", out JsonElement imagesProp2) && imagesProp2.GetArrayLength() > 0
                     ? $"{imagesProp2[0].GetProperty("width").GetInt32()}x{imagesProp2[0].GetProperty("height").GetInt32()}" : "UnknownResolution"

--- a/Tubifarry/Indexers/Spotify/TubifarryIndexer.cs
+++ b/Tubifarry/Indexers/Spotify/TubifarryIndexer.cs
@@ -41,6 +41,5 @@ namespace NzbDrone.Core.Indexers.Spotify
         public override IIndexerRequestGenerator GetRequestGenerator() => _indexerRequestGenerator;
 
         public override IParseIndexerResponse GetParser() => _parseIndexerResponse;
-
     }
 }

--- a/Tubifarry/Plugin.cs
+++ b/Tubifarry/Plugin.cs
@@ -10,28 +10,26 @@ namespace NzbDrone.Core.Plugins
         public override string Owner => "TypNull";
         public override string GithubUrl => "https://github.com/TypNull/Tubifarry";
 
-        private static Type ProtocolType => typeof(YoutubeDownloadProtocol);
+        private static Type[] ProtocolTypes => new Type[] { typeof(YoutubeDownloadProtocol), typeof(SoulseekDownloadProtocol) };
 
         public Tubifarry(IDelayProfileRepository repo, IEnumerable<IDownloadProtocol> downloadProtocols, Logger logger) => CheckDelayProfiles(repo, downloadProtocols, logger);
 
         private void CheckDelayProfiles(IDelayProfileRepository repo, IEnumerable<IDownloadProtocol> downloadProtocols, Logger logger)
         {
-            IDownloadProtocol? protocol = downloadProtocols.FirstOrDefault(x => x.GetType() == ProtocolType);
-            if (protocol == null)
-            {
-                logger.Error($"{ProtocolType} not found in download protocols.");
-                return;
-            }
+            IEnumerable<IDownloadProtocol> protocols = downloadProtocols.Where(x => ProtocolTypes.Any(y => y == x.GetType()));
 
-            logger.Debug($"Checking Protokol: {protocol.GetType().Name}");
-
-            foreach (DelayProfile? profile in repo.All())
+            foreach (IDownloadProtocol protocol in protocols)
             {
-                if (!profile.Items.Any(x => x.Protocol == protocol.GetType().Name))
+                logger.Trace($"Checking Protokol: {protocol.GetType().Name}");
+
+                foreach (DelayProfile? profile in repo.All())
                 {
-                    logger.Debug($"Added protocol to DelayProfile (ID: {profile.Id})");
-                    profile.Items.Add(GetProtocolItem(protocol, true));
-                    repo.Update(profile);
+                    if (!profile.Items.Any(x => x.Protocol == protocol.GetType().Name))
+                    {
+                        logger.Debug($"Added protocol to DelayProfile (ID: {profile.Id})");
+                        profile.Items.Add(GetProtocolItem(protocol, true));
+                        repo.Update(profile);
+                    }
                 }
             }
         }

--- a/Tubifarry/Plugin.cs
+++ b/Tubifarry/Plugin.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.Plugins
 
         public Tubifarry(IDelayProfileRepository repo, IEnumerable<IDownloadProtocol> downloadProtocols, Logger logger) => CheckDelayProfiles(repo, downloadProtocols, logger);
 
-        private void CheckDelayProfiles(IDelayProfileRepository repo, IEnumerable<IDownloadProtocol> downloadProtocols, Logger logger)
+        private static void CheckDelayProfiles(IDelayProfileRepository repo, IEnumerable<IDownloadProtocol> downloadProtocols, Logger logger)
         {
             IEnumerable<IDownloadProtocol> protocols = downloadProtocols.Where(x => ProtocolTypes.Any(y => y == x.GetType()));
 

--- a/Tubifarry/Tubifarry.csproj
+++ b/Tubifarry/Tubifarry.csproj
@@ -10,11 +10,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="FuzzySharp" Version="2.0.2" />
 		<PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.34.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Shard.DownloadAssistant" Version="1.0.8" />
+		<PackageReference Include="Shard.DownloadAssistant" Version="1.0.9" />
 		<PackageReference Include="Xabe.FFmpeg" Version="5.2.6" />
 		<PackageReference Include="Xabe.FFmpeg.Downloader" Version="5.2.6" />
 		<PackageReference Include="YouTubeMusicAPI" Version="2.1.1" />

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,0 +1,39 @@
+# Tubifarry Roadmap 🚀
+
+This roadmap outlines the future development plans and ideas for Tubifarry, a plugin for Lidarr that enhances music metadata fetching and downloading capabilities. The goal is to expand functionality, improve user experience, and integrate additional features to make Tubifarry a comprehensive tool for music management.
+
+---
+
+## Short-Term Goals (Next 3-6 Months) 🛠️
+
+### 1. **Soulseek Integration with slskd Support**
+   - **Objective**: Integrate Soulseek as a download client for Lidarr via slskd.
+   - **Features**:
+     - Add Soulseek as a download client option in Lidarr.
+     - Support for downloading music files directly from Soulseek.
+     - Configuration options for slskd (e.g., API key, download path).
+   - **Benefits**: Expand the range of music sources available for download, especially for rare or hard-to-find tracks.
+
+### 2. **Enhanced Import Lists**
+   - **Objective**: Add support for worldwide and country-specific music charts.
+   - **Features**:
+     - Fetch music charts from Spotify (global and country-specific).
+     - Add charts as import lists in Lidarr.
+     - Automatically populate Lidarr with trending albums and tracks.
+   - **Benefits**: Keep your music library up-to-date with the latest popular music.
+
+### 3. **Improved Metadata Fetching**
+   - **Objective**: Enhance metadata fetching from Deezer and other sources.
+   - **Features**:
+     - Populate Lidarr searches with albums from Deezer if not found on MusicBrainz or Lidarr Audio API.
+     - Add fallback mechanisms for metadata fetching to ensure comprehensive coverage.
+   - **Benefits**: Ensure that all music in your library has accurate and complete metadata.
+
+### 4. **Import Queue Management**
+   - **Objective**: Improve the handling of items in the import queue.
+   - **Features**:
+     - Remove warning items from the import queue automatically.
+     - Add options to automatically manage and clean up the import queue.
+   - **Benefits**: Streamline the import process and reduce manual intervention.
+
+---


### PR DESCRIPTION
- Integrated Slskd as a new source for Lidarr to enable Soulseek functionality
- Added configuration options for Slskd in the indexer settings
- Updated plugin documentation to include setup instructions for Soulseek support

This change allows Lidarr users to search and download music through the Soulseek network using Slskd, expanding the available sources for music discovery and acquisition.