### PR TITLE
Add Remote Path Mapping support

### DIFF
--- a/Tubifarry/Download/Clients/Soulseek/SlskdClient.cs
+++ b/Tubifarry/Download/Clients/Soulseek/SlskdClient.cs
@@ -203,7 +203,7 @@ namespace Tubifarry.Download.Clients.Soulseek
         public override DownloadClientInfo GetStatus() => new()
         {
             IsLocalhost = Settings.IsLocalhost,
-            OutputRootFolders = new List<OsPath> { _remotePathMappingService.RemapRemoteToLocal(Settings.BaseUrl, new OsPath(Settings.DownloadPath)) }
+            OutputRootFolders = new List<OsPath> { _remotePathMappingService.RemapRemoteToLocal(Settings.Host, new OsPath(Settings.DownloadPath)) }
         };
 
         private SlskdDownloadItem? GetDownloadItem(string downloadId) => GetDownloadItem(int.Parse(downloadId));

--- a/Tubifarry/Download/Clients/Soulseek/SlskdClient.cs
+++ b/Tubifarry/Download/Clients/Soulseek/SlskdClient.cs
@@ -203,7 +203,7 @@ namespace Tubifarry.Download.Clients.Soulseek
         public override DownloadClientInfo GetStatus() => new()
         {
             IsLocalhost = Settings.IsLocalhost,
-            OutputRootFolders = new List<OsPath> { Settings.IsRemotePath ? _remotePathMappingService.RemapRemoteToLocal(Settings.BaseUrl, new OsPath(Settings.DownloadPath)) : new OsPath(Settings.DownloadPath) }
+            OutputRootFolders = new List<OsPath> { _remotePathMappingService.RemapRemoteToLocal(Settings.BaseUrl, new OsPath(Settings.DownloadPath)) }
         };
 
         private SlskdDownloadItem? GetDownloadItem(string downloadId) => GetDownloadItem(int.Parse(downloadId));

--- a/Tubifarry/Download/Clients/Soulseek/SlskdClient.cs
+++ b/Tubifarry/Download/Clients/Soulseek/SlskdClient.cs
@@ -120,7 +120,7 @@ namespace Tubifarry.Download.Clients.Soulseek
 
             _logger.Trace($"Lyrics successfully written: {await metadataHandler.TryCreateLrcFileAsync(default)}");
         }));
-
+        
         public override IEnumerable<DownloadClientItem> GetItems()
         {
             UpdateDownloadItemsAsync().Wait();
@@ -128,6 +128,7 @@ namespace Tubifarry.Download.Clients.Soulseek
             foreach (DownloadClientItem? clientItem in GetDownloadItems().Select(x => x.GetDownloadClientItem(Settings.DownloadPath, Settings.GetTimeout())))
             {
                 clientItem.DownloadClientInfo = clientInfo;
+                clientItem.OutputPath = _remotePathMappingService.RemapRemoteToLocal(Settings.Host, clientItem.OutputPath);
                 yield return clientItem;
             }
         }

--- a/Tubifarry/Download/Clients/Soulseek/SlskdClient.cs
+++ b/Tubifarry/Download/Clients/Soulseek/SlskdClient.cs
@@ -120,7 +120,7 @@ namespace Tubifarry.Download.Clients.Soulseek
 
             _logger.Trace($"Lyrics successfully written: {await metadataHandler.TryCreateLrcFileAsync(default)}");
         }));
-        
+
         public override IEnumerable<DownloadClientItem> GetItems()
         {
             UpdateDownloadItemsAsync().Wait();

--- a/Tubifarry/Download/Clients/Soulseek/SlskdModels.cs
+++ b/Tubifarry/Download/Clients/Soulseek/SlskdModels.cs
@@ -78,13 +78,13 @@ namespace Tubifarry.Download.Clients.Soulseek
             }
         }
 
-        public OsPath GetFullFolderPath(string downloadPath) => new(Path.Combine(downloadPath, SlskdDownloadDirectory?.Directory
+        public OsPath GetFullFolderPath(OsPath downloadPath) => new(Path.Combine(downloadPath.FullPath, SlskdDownloadDirectory?.Directory
             .Replace('\\', '/')
             .TrimEnd('/')
             .Split('/')
             .LastOrDefault() ?? ""));
 
-        public DownloadClientItem GetDownloadClientItem(string downloadPath, TimeSpan? timeout)
+        public DownloadClientItem GetDownloadClientItem(OsPath downloadPath, TimeSpan? timeout)
         {
             _downloadClientItem.OutputPath = GetFullFolderPath(downloadPath);
             _downloadClientItem.Title = RemoteAlbum.Release.Title;

--- a/Tubifarry/Download/Clients/Soulseek/SlskdProviderSettings.cs
+++ b/Tubifarry/Download/Clients/Soulseek/SlskdProviderSettings.cs
@@ -1,4 +1,5 @@
-﻿using FluentValidation;
+﻿using System.Text.RegularExpressions;
+using FluentValidation;
 using NzbDrone.Core.Annotations;
 using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
@@ -50,6 +51,30 @@ namespace Tubifarry.Download.Clients.Soulseek
 
         [FieldDefinition(0, Label = "URL", Type = FieldType.Url, Placeholder = "http://localhost:5030", HelpText = "The URL of your Slskd instance.")]
         public string BaseUrl { get; set; } = "http://localhost:5030";
+
+        private string? _host;
+        public string Host
+        {
+            get
+            {
+                if (_host == null)
+                {
+                    var hostRegex = new Regex("(.+://)?(.+)(:|/)/");
+                    var hostMatch = hostRegex.Match(BaseUrl);
+                    if (!hostMatch.Success)
+                    {
+                        _host = BaseUrl;
+                    }
+                    else
+                    {
+                        _host = hostMatch.Groups[2].Value;
+                    }
+
+
+                }
+                return _host;
+            }
+        }
 
         [FieldDefinition(2, Label = "API Key", Type = FieldType.Textbox, Privacy = PrivacyLevel.ApiKey, HelpText = "The API key for your Slskd instance. You can find or set this in the Slskd's settings under 'Options'.", Placeholder = "Enter your API key")]
         public string ApiKey { get; set; } = string.Empty;

--- a/Tubifarry/Download/Clients/Soulseek/SlskdProviderSettings.cs
+++ b/Tubifarry/Download/Clients/Soulseek/SlskdProviderSettings.cs
@@ -62,7 +62,7 @@ namespace Tubifarry.Download.Clients.Soulseek
             {
                 if (_host == null)
                 {
-                    var hostRegex = new Regex("(.+://)?(.+)(:|/)/");
+                    var hostRegex = new Regex("(.+://)?(.+)(:|/)");
                     var hostMatch = hostRegex.Match(BaseUrl);
                     if (!hostMatch.Success)
                     {

--- a/Tubifarry/Download/Clients/Soulseek/SlskdProviderSettings.cs
+++ b/Tubifarry/Download/Clients/Soulseek/SlskdProviderSettings.cs
@@ -72,8 +72,6 @@ namespace Tubifarry.Download.Clients.Soulseek
                     {
                         _host = hostMatch.Groups[2].Value;
                     }
-
-
                 }
                 return _host;
             }

--- a/Tubifarry/Download/Clients/Soulseek/SlskdProviderSettings.cs
+++ b/Tubifarry/Download/Clients/Soulseek/SlskdProviderSettings.cs
@@ -1,8 +1,8 @@
-﻿using System.Text.RegularExpressions;
-using FluentValidation;
+﻿using FluentValidation;
 using NzbDrone.Core.Annotations;
 using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
+using System.Text.RegularExpressions;
 
 namespace Tubifarry.Download.Clients.Soulseek
 {
@@ -20,12 +20,6 @@ namespace Tubifarry.Download.Clients.Soulseek
             RuleFor(c => c.ApiKey)
                 .NotEmpty()
                 .WithMessage("API Key is required.");
-
-            // Validate DownloadPath can be null or empty, or a valid directory path
-            RuleFor(x => x.DownloadPath)
-                .Must(path => string.IsNullOrEmpty(path) || Path.IsPathRooted(path))
-                .WithMessage("Download path must be a valid directory path.")
-                .When(x => !string.IsNullOrEmpty(x.DownloadPath));
 
             // Validate LRCLIBInstance URL
             RuleFor(x => x.LRCLIBInstance)
@@ -47,53 +41,23 @@ namespace Tubifarry.Download.Clients.Soulseek
 
     public class SlskdProviderSettings : IProviderConfig
     {
+        private static readonly Regex _hostRegex = new(@"^(?:https?:\/\/)?([^\/:\?]+)(?::\d+)?(?:\/|$)", RegexOptions.Compiled);
         private static readonly SlskdProviderSettingsValidator Validator = new();
+        private string? _host;
 
         [FieldDefinition(0, Label = "URL", Type = FieldType.Url, Placeholder = "http://localhost:5030", HelpText = "The URL of your Slskd instance.")]
         public string BaseUrl { get; set; } = "http://localhost:5030";
 
-        private string? _host;
-
-
-        [FieldDefinition(0, Label = "Host", Type = FieldType.Textbox, Hidden = HiddenType.Hidden)]
-        public string Host
-        {
-            get
-            {
-                if (_host == null)
-                {
-                    var hostRegex = new Regex("(.+://)?(.+)(:|/)");
-                    var hostMatch = hostRegex.Match(BaseUrl);
-                    if (!hostMatch.Success)
-                    {
-                        _host = BaseUrl;
-                    }
-                    else
-                    {
-                        _host = hostMatch.Groups[2].Value;
-                    }
-                }
-                return _host;
-            }
-            set
-            {
-                // Nothing to do; setter required by Lidarr when saving the config
-            }
-        }
-
-        [FieldDefinition(2, Label = "API Key", Type = FieldType.Textbox, Privacy = PrivacyLevel.ApiKey, HelpText = "The API key for your Slskd instance. You can find or set this in the Slskd's settings under 'Options'.", Placeholder = "Enter your API key")]
+        [FieldDefinition(1, Label = "API Key", Type = FieldType.Textbox, Privacy = PrivacyLevel.ApiKey, HelpText = "The API key for your Slskd instance. You can find or set this in the Slskd's settings under 'Options'.", Placeholder = "Enter your API key")]
         public string ApiKey { get; set; } = string.Empty;
 
-        [FieldDefinition(3, Label = "Download Path", Type = FieldType.Path, HelpText = "Specify the directory where downloaded files will be saved. If not specified, Slskd's default download path is used.")]
-        public string DownloadPath { get; set; } = string.Empty;
-
-        [FieldDefinition(5, Label = "Use LRCLIB for Lyrics", HelpText = "Enable this option to fetch lyrics from LRCLIB after the download is complete.", Type = FieldType.Checkbox)]
+        [FieldDefinition(2, Label = "Use LRCLIB for Lyrics", HelpText = "Enable this option to fetch lyrics from LRCLIB after the download is complete.", Type = FieldType.Checkbox)]
         public bool UseLRCLIB { get; set; } = false;
 
-        [FieldDefinition(6, Label = "LRC Lib Instance", Type = FieldType.Url, HelpText = "The URL of a LRC Lib instance to connect to. Default is 'https://lrclib.net'.", Advanced = true)]
+        [FieldDefinition(3, Label = "LRC Lib Instance", Type = FieldType.Url, HelpText = "The URL of a LRC Lib instance to connect to. Default is 'https://lrclib.net'.", Advanced = true)]
         public string LRCLIBInstance { get; set; } = "https://lrclib.net";
 
-        [FieldDefinition(7, Label = "Timeout", Type = FieldType.Textbox, HelpText = "Specify the maximum time to wait for a response from the Slskd instance before timing out. Fractional values are allowed (e.g., 1.5 for 1 hour and 30 minutes). Set leave blank for no timeout.", Unit = "hours", Advanced = true, Placeholder = "Enter timeout in hours")]
+        [FieldDefinition(4, Label = "Timeout", Type = FieldType.Textbox, HelpText = "Specify the maximum time to wait for a response from the Slskd instance before timing out. Fractional values are allowed (e.g., 1.5 for 1 hour and 30 minutes). Set leave blank for no timeout.", Unit = "hours", Advanced = true, Placeholder = "Enter timeout in hours")]
         public double? Timeout { get; set; }
 
         [FieldDefinition(8, Label = "Retry Attempts", Type = FieldType.Number, HelpText = "The number of times to retry downloading a file if it fails.", Advanced = true, Placeholder = "Enter retry attempts")]
@@ -102,8 +66,16 @@ namespace Tubifarry.Download.Clients.Soulseek
         [FieldDefinition(98, Label = "Is Fetched remote", Type = FieldType.Checkbox, Hidden = HiddenType.Hidden)]
         public bool IsRemotePath { get; set; }
 
-        [FieldDefinition(99, Label = "Is Localhost", Type = FieldType.Checkbox, Hidden = HiddenType.Hidden)]
+        [FieldDefinition(99, Label = "Host", Type = FieldType.Textbox, Hidden = HiddenType.Hidden)]
+        public string Host
+        {
+            get => _host ??= (_hostRegex.Match(BaseUrl) is { Success: true } match) ? match.Groups[1].Value : BaseUrl;
+            set { }
+        }
+
         public bool IsLocalhost { get; set; }
+
+        public string DownloadPath { get; set; } = string.Empty;
 
         public TimeSpan? GetTimeout() => Timeout == null ? null : TimeSpan.FromHours(Timeout.Value);
 

--- a/Tubifarry/Download/Clients/Soulseek/SlskdProviderSettings.cs
+++ b/Tubifarry/Download/Clients/Soulseek/SlskdProviderSettings.cs
@@ -77,6 +77,10 @@ namespace Tubifarry.Download.Clients.Soulseek
                 }
                 return _host;
             }
+            set
+            {
+                // Nothing to do
+            }
         }
 
         [FieldDefinition(2, Label = "API Key", Type = FieldType.Textbox, Privacy = PrivacyLevel.ApiKey, HelpText = "The API key for your Slskd instance. You can find or set this in the Slskd's settings under 'Options'.", Placeholder = "Enter your API key")]

--- a/Tubifarry/Download/Clients/Soulseek/SlskdProviderSettings.cs
+++ b/Tubifarry/Download/Clients/Soulseek/SlskdProviderSettings.cs
@@ -79,7 +79,7 @@ namespace Tubifarry.Download.Clients.Soulseek
             }
             set
             {
-                // Nothing to do
+                // Nothing to do; setter required by Lidarr when saving the config
             }
         }
 

--- a/Tubifarry/Download/Clients/Soulseek/SlskdProviderSettings.cs
+++ b/Tubifarry/Download/Clients/Soulseek/SlskdProviderSettings.cs
@@ -53,6 +53,9 @@ namespace Tubifarry.Download.Clients.Soulseek
         public string BaseUrl { get; set; } = "http://localhost:5030";
 
         private string? _host;
+
+
+        [FieldDefinition(0, Label = "Host", Type = FieldType.Textbox, Hidden = HiddenType.Hidden)]
         public string Host
         {
             get


### PR DESCRIPTION
This PR aims to add Remote Path Mapping support to the SlskdClient so Lidarr can successfully import downloaded files when the Lidarr container and the slskd container don't have the same volume mapping for the download directory.

1. In order to have the client show up as an option in the "Add Remote Path Mapping" dialog, the settings need to have a `Host` property. I added it as a "readonly" property that uses the `BaseUrl` and a regex to determine the host and keep the result so the regex isn't used too often. There is an empty setter for the property because the download client settings could not be saved otherwise.
    - You can find the (few) test cases I used for the regex here : https://regex101.com/r/gauTJP/1.
    - The last 2 cases don't match using the regex, but the whole value is the host itself, which is why I added that if there is no match, `Host` simply returns `BaseUrl`.
2. Added a call to the remote path mapping service in the GetItems function to override the download client path with the Lidarr container's path.
3. This is the part I'm not 100% sure about. Updated the GetStatus method to always use the remote path mapping service, and use the new Host property instead of the BaseUrl property since that's what the path mapping is using. This was needed because Lidarr would have an error status message about the download path not existing in the Lidarr container. Also, I'm not sure what the original code was supposed to accomplish since if there is no remote path mapping configured for Slskd, the original path is returned by the service.

Let me know if there is anything to fix or clean up.