### PR TITLE
Fixed typo in SlskdIndexer.cs

### DIFF
--- a/Tubifarry/Indexers/Soulseek/SlskdIndexer.cs
+++ b/Tubifarry/Indexers/Soulseek/SlskdIndexer.cs
@@ -12,7 +12,7 @@ namespace Tubifarry.Indexers.Soulseek
 {
     public class SlskdIndexer : HttpIndexerBase<SlskdSettings>
     {
-        public override string Name => "Slsdk";
+        public override string Name => "Slskd";
         public override string Protocol => nameof(SoulseekDownloadProtocol);
         public override bool SupportsRss => false;
         public override bool SupportsSearch => true;


### PR DESCRIPTION
It said "Slsdk" when selecting an Indexer. Fixed typo on line 15 of Tubifarry/Indexers/Soulseek/SlskdIndexer.cs