### PR TITLE
add wildcard fallback tier

### DIFF
--- a/Tubifarry/Indexers/Soulseek/SlskdRequestGenerator.cs
+++ b/Tubifarry/Indexers/Soulseek/SlskdRequestGenerator.cs
@@ -151,6 +151,20 @@ namespace Tubifarry.Indexers.Soulseek
 
         private void AddFallbackTiers(LazyIndexerPageableRequestChain chain, SearchParameters searchParams)
         {
+            if (searchParams.Artist != null)
+            {
+                // Artist with wildcard substitution
+                chain.AddTierFactory(SearchTierGenerator.CreateTier(() =>
+                    ExecuteSearch(
+                        $"*{searchParams.Artist[1..]}",
+                        searchParams.Album,
+                        searchParams.Interactive,
+                        false,
+                        searchParams.TrackCount
+                    )
+                ));   
+            }
+            
             // Artist aliases (limit to 2)
             for (int i = 0; i < Math.Min(2, searchParams.Aliases.Count); i++)
             {


### PR DESCRIPTION
Soulseek selectively filters for direct searches by particular artists, so by including a wildcard `*` in the search you can perform a reasonably close search while avoiding the filtered artist names.

I've tried my searches with the existing fallback logic but it was unable to avoid this issue like including a wildcard `*` can.