### PR TITLE
Update YouTubeMusicAPI version to 3.0.6

### DIFF
--- a/Tubifarry/Tubifarry.csproj
+++ b/Tubifarry/Tubifarry.csproj
@@ -28,7 +28,7 @@
 		<PackageReference Include="System.Text.Json" Version="8.0.6" GeneratePathProperty="true" />
 		<PackageReference Include="Xabe.FFmpeg" Version="6.0.2" />
 		<PackageReference Include="Xabe.FFmpeg.Downloader" Version="6.0.2" />
-		<PackageReference Include="YouTubeMusicAPI" Version="3.0.4" />
+		<PackageReference Include="YouTubeMusicAPI" Version="3.0.6" />
 		<PackageReference Include="YouTubeSessionGenerator" Version="1.0.3" />
 	</ItemGroup>
 	


### PR DESCRIPTION
Youtube did some changes and the upstream packages now have reported issues of `Failed to extract signature deciphering function.` (https://github.com/IcySnex/YouTubeMusicAPI/issues/35). This happens in Lidarr with this plugin as well:

```
System.Exception: Failed to extract signature deciphering function
   at YouTubeMusicAPI.Internal.Player.CreateAsync(RequestHelper requestHelper, String poToken, CancellationToken cancellationToken)
   at YouTubeMusicAPI.Client.YouTubeMusicClient.GetStreamingDataAsync(String id, CancellationToken cancellationToken)
   at Tubifarry.Download.Clients.YouTube.YouTubeDownloadRequest.ProcessAlbumAsync(String downloadUrl, CancellationToken token)
```

The 3.0.6 version of YouTubeMusicAPI should solve this issue.