### PR TITLE
Fix LastFM duration JSON string-to-int parsing

### DIFF
--- a/Tubifarry/ImportLists/LastFmRecommendation/LastFmRecords.cs
+++ b/Tubifarry/ImportLists/LastFmRecommendation/LastFmRecords.cs
@@ -15,7 +15,7 @@ namespace Tubifarry.ImportLists.LastFmRecommendation
 
     public record LastFmTrack(
         [property: JsonPropertyName("name")] string Name,
-        [property: JsonPropertyName("duration")] int Duration,
+        [property: JsonPropertyName("duration"), JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)] int Duration,
         [property: JsonPropertyName("url")] string Url,
         [property: JsonPropertyName("artist")] LastFmArtist Artist
     );


### PR DESCRIPTION
Attempting to resolve https://github.com/TypNull/Tubifarry/issues/168

I used AI to determine the issue and fix, but I was unsuccessful to try testing the fix locally. 