### PR TITLE
Fixed: ffmpeg 8.0 compatibility in audio format conversion

### DIFF
--- a/Tubifarry/Core/Model/AudioMetadataHandler.cs
+++ b/Tubifarry/Core/Model/AudioMetadataHandler.cs
@@ -1,6 +1,3 @@
-using NLog;
-using NzbDrone.Common.Instrumentation;
-using NzbDrone.Core.Music;
 using Tubifarry.Core.Records;
 using Tubifarry.Core.Utilities;
 using Xabe.FFmpeg;
@@ -203,7 +200,7 @@ namespace Tubifarry.Core.Model
                 try
                 {
                     IConversion conversion = FFmpeg.Conversions.New()
-                        .AddParameter($"-i \"{TrackPath}\"")
+                        .AddParameter($"-i {TrackPath.Escape()}")
                         .AddParameter("-an -vcodec copy")
                         .SetOutput(tempCoverPath);
 
@@ -226,19 +223,9 @@ namespace Tubifarry.Core.Model
         /// <summary>
         /// Creates a base FFmpeg conversion using explicit stream mapping.
         /// </summary>
-        /// <remarks>
-        /// Uses <see cref="FFmpeg.Conversions.New"/> rather than the <c>FromSnippet</c> helpers.
-        /// The snippet helpers are async because they call <c>GetMediaInfo</c> internally to
-        /// auto-discover streams, then emit <c>-c:v copy</c> for every video stream. When the
-        /// caller subsequently appends <c>-c:v mjpeg</c> for cover art, ffmpeg 8.0+ rejects the
-        /// duplicate codec directive with EINVAL. Using <c>New()</c> with an explicit
-        /// <c>-map 0:a:0</c> eliminates both the duplicate directive and the redundant
-        /// <c>GetMediaInfo</c> probe (callers already invoke it for their own purposes).
-        /// Music files and single-track video sources never have more than one audio stream.
-        /// </remarks>
         private static IConversion CreateBaseAudioConversion(string inputPath, string outputPath) =>
             FFmpeg.Conversions.New()
-                .AddParameter($"-i \"{inputPath}\"")
+                .AddParameter($"-i {inputPath.Escape()}")
                 .AddParameter("-map 0:a:0")
                 .SetOutput(outputPath);
 
@@ -384,7 +371,7 @@ namespace Tubifarry.Core.Model
                 if (hasRealVideo)
                     return true;
 
-                string probeResult = await Probe.New().Start($"-v error -show_entries format=format_name -of default=noprint_wrappers=1:nokey=1 \"{TrackPath}\"");
+                string probeResult = await Probe.New().Start($"-v error -show_entries format=format_name -of default=noprint_wrappers=1:nokey=1 {TrackPath.Escape()}");
                 string formatName = probeResult?.Trim().ToLower() ?? "";
                 return VideoFormats.Any(container => formatName.Contains(container));
             }
@@ -477,7 +464,7 @@ namespace Tubifarry.Core.Model
 
                 IConversion conversion = FFmpeg.Conversions.New()
                     .AddParameter($"-decryption_key {decryptionKey}")
-                    .AddParameter($"-i \"{TrackPath}\"")
+                    .AddParameter($"-i {TrackPath.Escape()}")
                     .AddParameter("-c copy")
                     .SetOutput(tempOutput);
 

--- a/Tubifarry/Core/Model/AudioMetadataHandler.cs
+++ b/Tubifarry/Core/Model/AudioMetadataHandler.cs
@@ -224,6 +224,25 @@ namespace Tubifarry.Core.Model
         }
 
         /// <summary>
+        /// Creates a base FFmpeg conversion using explicit stream mapping.
+        /// </summary>
+        /// <remarks>
+        /// Uses <see cref="FFmpeg.Conversions.New"/> rather than the <c>FromSnippet</c> helpers.
+        /// The snippet helpers are async because they call <c>GetMediaInfo</c> internally to
+        /// auto-discover streams, then emit <c>-c:v copy</c> for every video stream. When the
+        /// caller subsequently appends <c>-c:v mjpeg</c> for cover art, ffmpeg 8.0+ rejects the
+        /// duplicate codec directive with EINVAL. Using <c>New()</c> with an explicit
+        /// <c>-map 0:a:0</c> eliminates both the duplicate directive and the redundant
+        /// <c>GetMediaInfo</c> probe (callers already invoke it for their own purposes).
+        /// Music files and single-track video sources never have more than one audio stream.
+        /// </remarks>
+        private static IConversion CreateBaseAudioConversion(string inputPath, string outputPath) =>
+            FFmpeg.Conversions.New()
+                .AddParameter($"-i \"{inputPath}\"")
+                .AddParameter("-map 0:a:0")
+                .SetOutput(outputPath);
+
+        /// <summary>
         /// Converts audio to the specified format with optional bitrate control.
         /// </summary>
         /// <param name="audioFormat">Target audio format</param>
@@ -262,13 +281,7 @@ namespace Tubifarry.Core.Model
                 IMediaInfo mediaInfo = await FFmpeg.GetMediaInfo(TrackPath);
                 bool hasCoverArt = mediaInfo.VideoStreams.Any(vs => CoverArtCodecs.Contains(vs.Codec ?? ""));
 
-                // Use explicit stream mapping instead of FromSnippet.Convert() which auto-generates
-                // "-c:v copy" for all streams. ffmpeg 8.0+ rejects duplicate codec specs for the
-                // same stream (e.g. "-c:v copy" followed by "-c:v mjpeg"), returning EINVAL.
-                IConversion conversion = FFmpeg.Conversions.New()
-                    .AddParameter($"-i \"{TrackPath}\"")
-                    .AddParameter("-map 0:a:0")
-                    .SetOutput(tempOutputPath);
+                IConversion conversion = CreateBaseAudioConversion(TrackPath, tempOutputPath);
 
                 if (hasCoverArt)
                 {
@@ -411,12 +424,7 @@ namespace Tubifarry.Core.Model
                 if (File.Exists(tempOutputPath))
                     File.Delete(tempOutputPath);
 
-                // Use explicit stream mapping instead of FromSnippet.ExtractAudio() for ffmpeg 8.0+
-                // compatibility; the snippet helper generates conflicting codec directives.
-                IConversion conversion = FFmpeg.Conversions.New()
-                    .AddParameter($"-i \"{TrackPath}\"")
-                    .AddParameter("-map 0:a:0")
-                    .SetOutput(tempOutputPath);
+                IConversion conversion = CreateBaseAudioConversion(TrackPath, tempOutputPath);
                 foreach (string parameter in ExtractionParameters)
                     conversion.AddParameter(parameter);
 

--- a/Tubifarry/Core/Model/AudioMetadataHandler.cs
+++ b/Tubifarry/Core/Model/AudioMetadataHandler.cs
@@ -259,11 +259,20 @@ namespace Tubifarry.Core.Model
 
                 byte[]? preservedCoverArt = AlbumCover?.Length > 0 ? AlbumCover : await TryExtractCoverArtAsync();
 
-                IConversion conversion = await FFmpeg.Conversions.FromSnippet.Convert(TrackPath, tempOutputPath);
-
                 IMediaInfo mediaInfo = await FFmpeg.GetMediaInfo(TrackPath);
-                if (mediaInfo.VideoStreams.Any(vs => CoverArtCodecs.Contains(vs.Codec ?? "")))
+                bool hasCoverArt = mediaInfo.VideoStreams.Any(vs => CoverArtCodecs.Contains(vs.Codec ?? ""));
+
+                // Use explicit stream mapping instead of FromSnippet.Convert() which auto-generates
+                // "-c:v copy" for all streams. ffmpeg 8.0+ rejects duplicate codec specs for the
+                // same stream (e.g. "-c:v copy" followed by "-c:v mjpeg"), returning EINVAL.
+                IConversion conversion = FFmpeg.Conversions.New()
+                    .AddParameter($"-i \"{TrackPath}\"")
+                    .AddParameter("-map 0:a:0")
+                    .SetOutput(tempOutputPath);
+
+                if (hasCoverArt)
                 {
+                    conversion.AddParameter("-map 0:v:0");
                     conversion.AddParameter("-c:v mjpeg -q:v 2 -disposition:v attached_pic");
                     _logger?.Trace("Detected attached picture stream, re-encoding as mjpeg with attached_pic disposition");
                 }
@@ -402,7 +411,12 @@ namespace Tubifarry.Core.Model
                 if (File.Exists(tempOutputPath))
                     File.Delete(tempOutputPath);
 
-                IConversion conversion = await FFmpeg.Conversions.FromSnippet.ExtractAudio(TrackPath, tempOutputPath);
+                // Use explicit stream mapping instead of FromSnippet.ExtractAudio() for ffmpeg 8.0+
+                // compatibility; the snippet helper generates conflicting codec directives.
+                IConversion conversion = FFmpeg.Conversions.New()
+                    .AddParameter($"-i \"{TrackPath}\"")
+                    .AddParameter("-map 0:a:0")
+                    .SetOutput(tempOutputPath);
                 foreach (string parameter in ExtractionParameters)
                     conversion.AddParameter(parameter);
 

--- a/Tubifarry/Download/Clients/YouTube/SponsorBlock.cs
+++ b/Tubifarry/Download/Clients/YouTube/SponsorBlock.cs
@@ -124,7 +124,7 @@ namespace Tubifarry.Download.Clients.YouTube
                         string segmentFile = Path.Combine(tempDir, $"segment_{segmentIndex:D3}{Path.GetExtension(_filePath)}");
 
                         IConversion extraction = FFmpeg.Conversions.New()
-                            .AddParameter($"-i \"{_filePath}\"")
+                            .AddParameter($"-i {_filePath.Escape()}")
                             .AddParameter($"-ss {previousEnd.ToString("F3", CultureInfo.InvariantCulture)}")
                             .AddParameter($"-to {segmentStart.ToString("F3", CultureInfo.InvariantCulture)}")
                             .AddParameter("-c copy")
@@ -146,7 +146,7 @@ namespace Tubifarry.Download.Clients.YouTube
                     string segmentFile = Path.Combine(tempDir, $"segment_{segmentIndex:D3}{Path.GetExtension(_filePath)}");
 
                     IConversion extraction = FFmpeg.Conversions.New()
-                        .AddParameter($"-i \"{_filePath}\"")
+                        .AddParameter($"-i {_filePath.Escape()}")
                         .AddParameter($"-ss {previousEnd.ToString("F3", CultureInfo.InvariantCulture)}")
                         .AddParameter("-c copy")
                         .AddParameter("-map 0")  // Copy all streams
@@ -175,8 +175,8 @@ namespace Tubifarry.Download.Clients.YouTube
                 IConversion concat = FFmpeg.Conversions.New()
                     .AddParameter("-f concat")
                     .AddParameter("-safe 0")
-                    .AddParameter($"-i \"{concatListPath}\"")
-                    .AddParameter($"-i \"{_filePath}\"")  // Add original file for metadata
+                    .AddParameter($"-i {concatListPath.Escape()}")
+                    .AddParameter($"-i {_filePath.Escape()}")  // Add original file for metadata
                     .AddParameter("-c copy")
                     .AddParameter("-map 0")  // Map concat result
                     .AddParameter("-map_metadata 1")  // Take metadata from original file

--- a/Tubifarry/Metadata/Converter/AudioConverter.cs
+++ b/Tubifarry/Metadata/Converter/AudioConverter.cs
@@ -90,7 +90,7 @@ namespace Tubifarry.Metadata.Converter
         {
             try
             {
-                string probeArgs = $"-v error -select_streams a:0 -show_entries stream=bits_per_raw_sample,sample_fmt -of default=noprint_wrappers=1 \"{filePath}\"";
+                string probeArgs = $"-v error -select_streams a:0 -show_entries stream=bits_per_raw_sample,sample_fmt -of default=noprint_wrappers=1 {filePath.Escape()}";
                 string probeOutput = await Probe.New().Start(probeArgs);
 
                 if (string.IsNullOrWhiteSpace(probeOutput))


### PR DESCRIPTION
## Problem

On systems running ffmpeg 8.0+, `TryConvertToFormatAsync` and `TryExtractAudioFromVideoAsync` fail with:

```
Error opening output file /tmp/…converted.mp3.
Error initializing output stream …: Invalid argument
```

The root cause is that `FFmpeg.Conversions.FromSnippet.Convert()` and `FromSnippet.ExtractAudio()` auto-generate `-c:v copy` for all input streams. When cover art is detected, Tubifarry then appends `-c:v mjpeg`, producing duplicate codec directives for the same video stream:

```
-c:v copy … -c:v mjpeg -q:v 2 -disposition:v attached_pic
```

ffmpeg 8.0 enforces strict muxer validation before opening the output file and rejects this with `EINVAL`. ffmpeg 7.x silently used the last directive.

Reference: https://github.com/FFmpeg/FFmpeg/blob/n8.0.1/Changelog

## Fix

Replace both `FromSnippet` calls with `FFmpeg.Conversions.New()` — the same pattern already used in `TryDecryptAsync` — and build stream mapping explicitly:

- Always map `0:a:0` (first audio stream)
- Map `0:v:0` + `-c:v mjpeg` **only when** cover art is detected, eliminating any possibility of duplicate codec directives

The `FromSnippet` helpers are async because they call `GetMediaInfo` internally to auto-discover streams. Both callers already invoke `GetMediaInfo` for their own purposes (cover art detection and audio codec determination respectively), so the `FromSnippet` call was also a redundant second probe each time. Replacing it with the synchronous `Conversions.New()` builder is therefore behaviourally equivalent, not just a style change.

To avoid duplicating the pattern, a private `CreateBaseAudioConversion` helper consolidates the `Conversions.New()` construction and documents the rationale in one place.

No behaviour change on ffmpeg 7.x or older. All existing codec, bitrate, and bit-depth parameters are preserved.

## Testing

Tested against a FLAC file with embedded JPEG cover art using ffmpeg 8.0.1. Conversion to MP3 completes successfully and cover art is preserved.