### PR TITLE
(Soulseek) Add sample rate to extra info when present

### DIFF
--- a/Tubifarry/Indexers/Soulseek/SlskdItemsParser.cs
+++ b/Tubifarry/Indexers/Soulseek/SlskdItemsParser.cs
@@ -164,7 +164,7 @@ namespace Tubifarry.Indexers.Soulseek
                 ExplicitContent = ExtractExplicitTag(folderData.Path),
                 Priotity = priority,
                 CustomString = JsonConvert.SerializeObject(filesToDownload),
-                ExtraInfo = [edition, $"👤 {folderData.Username} ", $"{(folderData.HasFreeUploadSlot ? "⚡" : "❌")} {folderData.UploadSpeed / 1024.0 / 1024.0:F2}MB/s ", folderData.QueueLength == 0 ? "" : $"📋 {folderData.QueueLength}"],
+                ExtraInfo = [qualityInfo, edition, $"👤 {folderData.Username} ", $"{(folderData.HasFreeUploadSlot ? "⚡" : "❌")} {folderData.UploadSpeed / 1024.0 / 1024.0:F2}MB/s ", folderData.QueueLength == 0 ? "" : $"📋 {folderData.QueueLength}"],
                 Duration = TotalDuration
             };
         }
@@ -498,13 +498,9 @@ namespace Tubifarry.Indexers.Soulseek
 
         private static string FormatQualityInfo(AudioFormat codec, int? bitRate, int? bitDepth, int? sampleRate)
         {
-            if (codec == AudioFormat.MP3 && bitRate.HasValue)
-                return $"{codec} {bitRate}kbps";
-
             if (bitDepth.HasValue && sampleRate.HasValue)
-                return $"{codec} {bitDepth}bit/{sampleRate / 1000}kHz";
-
-            return codec.ToString();
+                return $"{sampleRate / 1000}kHz";
+            return null;
         }
 
         [GeneratedRegex(@"(?ix)


### PR DESCRIPTION
Implements #210 . Repurposes unused qualityInfo string and FormatQualityInfo function. Is only present when present on slskd. Should immediately follow codec.
Example screenshot:
<img width="193" height="291" alt="Screenshot 2026-08-11 033550" src="https://github.com/user-attachments/assets/44fd42e7-e354-4eaa-a913-c1a4019046e1" />
(uploader username blacked out)