### PR TITLE
Change URL mapper to match latest Lidarr change from commit 62af818b7

### DIFF
--- a/Tubifarry/Metadata/Proxy/MetadataProvider/CustomLidarr/CustomLidarrProxy.cs
+++ b/Tubifarry/Metadata/Proxy/MetadataProvider/CustomLidarr/CustomLidarrProxy.cs
@@ -591,11 +591,7 @@ namespace Tubifarry.Metadata.Proxy.MetadataProvider.CustomLidarr
 
         private static MediaCover MapImage(ImageResource arg)
         {
-            return new MediaCover
-            {
-                Url = arg.Url,
-                CoverType = MapCoverType(arg.CoverType)
-            };
+            return new MediaCover(MapCoverType(arg.CoverType), arg.Url);
         }
 
         private static Links MapLink(LinkResource arg) => new()

--- a/Tubifarry/Metadata/Proxy/MetadataProvider/Discogs/DiscogsMappingHelper.cs
+++ b/Tubifarry/Metadata/Proxy/MetadataProvider/Discogs/DiscogsMappingHelper.cs
@@ -163,12 +163,7 @@ namespace Tubifarry.Metadata.Proxy.MetadataProvider.Discogs
         /// <summary>
         /// Maps a Discogs image to a MediaCover object.
         /// </summary>
-        public static MediaCover? MapImage(DiscogsImage img, bool isArtist) => new()
-        {
-            Url = img.Uri,
-            RemoteUrl = img.Uri,
-            CoverType = MapCoverType(img.Type, isArtist)
-        };
+        public static MediaCover? MapImage(DiscogsImage img, bool isArtist) => new(MapCoverType(img.Type, isArtist), img.Uri);
 
         /// <summary>
         /// Maps a Discogs image type to a MediaCoverTypes enum.
@@ -445,7 +440,7 @@ namespace Tubifarry.Metadata.Proxy.MetadataProvider.Discogs
                 CleanTitle = release.Title.CleanArtistName() ?? string.Empty,
                 Ratings = new Ratings(),
                 Genres = [release.Label ?? string.Empty],
-                Images = [new() { Url = release.Thumb + $"?{FlexibleHttpDispatcher.UA_PARAM}={release.UserAgent}" }],
+                Images = [new(MapCoverType("primary", false), release.Thumb + $"?{FlexibleHttpDispatcher.UA_PARAM}={release.UserAgent}")],
             };
 
             album.AlbumReleases = new List<AlbumRelease>()
@@ -560,7 +555,7 @@ namespace Tubifarry.Metadata.Proxy.MetadataProvider.Discogs
                 Name = searchItem.Title ?? string.Empty,
                 ForeignArtistId = "a" + searchItem.Id + _identifier,
                 Overview = "Found on Discogs",
-                Images = [new() { Url = searchItem.Thumb + $"?{FlexibleHttpDispatcher.UA_PARAM}={searchItem.UserAgent}", CoverType = MapCoverType("primary", true) }],
+                Images = [new(MapCoverType("primary", true), searchItem.Thumb + $"?{FlexibleHttpDispatcher.UA_PARAM}={searchItem.UserAgent}")],
                 Links = [new() { Url = searchItem.ResourceUrl, Name = "Discogs" }],
                 Ratings = ComputeCommunityRating(searchItem.Community),
                 Genres = searchItem.Genre,

--- a/Tubifarry/Metadata/Proxy/MetadataProvider/Lastfm/LastfmMappingHelper.cs
+++ b/Tubifarry/Metadata/Proxy/MetadataProvider/Lastfm/LastfmMappingHelper.cs
@@ -276,11 +276,7 @@ namespace Tubifarry.Metadata.Proxy.MetadataProvider.Lastfm
         {
             return images?
                 .Where(i => !string.IsNullOrEmpty(i.Url))
-                .Select(i => new MediaCover
-                {
-                    Url = i.Url,
-                    CoverType = MapCoverType(i.Size + $"{FlexibleHttpDispatcher.UA_PARAM}={userAgent}", isArtist)
-                })
+                .Select(i => new MediaCover(MapCoverType(i.Size + $"{FlexibleHttpDispatcher.UA_PARAM}={userAgent}", isArtist), i.Url))
                 .ToList() ?? [];
         }
 

--- a/Tubifarry/Metadata/Proxy/MetadataProvider/Lastfm/LastfmProxy.cs
+++ b/Tubifarry/Metadata/Proxy/MetadataProvider/Lastfm/LastfmProxy.cs
@@ -209,11 +209,7 @@ namespace Tubifarry.Metadata.Proxy.MetadataProvider.Lastfm
                 for (int i = 0; i < Math.Min(imageUrls.Count, 3); i++)
                 {
                     MediaCoverTypes type = i == 0 ? MediaCoverTypes.Poster : MediaCoverTypes.Fanart;
-                    newImages.Add(new MediaCover
-                    {
-                        Url = imageUrls[i],
-                        CoverType = type
-                    });
+                    newImages.Add(new MediaCover(type, imageUrls[i]));
                 }
                 artist.Metadata.Value.Images = newImages;
 

--- a/Tubifarry/Metadata/Proxy/RecommendArtists/LastFmSimilarArtistsService.cs
+++ b/Tubifarry/Metadata/Proxy/RecommendArtists/LastFmSimilarArtistsService.cs
@@ -273,11 +273,7 @@ namespace Tubifarry.Metadata.Proxy.RecommendArtists
         /// </summary>
         private static List<MediaCover> MapLastfmImages(List<LastfmImage>? images) => images?
             .Where(i => !string.IsNullOrEmpty(i.Url))
-            .Select(i => new MediaCover
-            {
-                Url = i.Url,
-                CoverType = MapImageSize(i.Size)
-            }).ToList() ?? [];
+            .Select(i => new MediaCover(MapImageSize(i.Size), i.Url)).ToList() ?? [];
 
         /// <summary>
         /// Maps Last.fm image size to MediaCoverTypes


### PR DESCRIPTION
Lidarr commit 62af818b7 Fixed: Images for some artists not downloading changed MediaCover so covers are HEADed/downloaded from RemoteUrl instead of Url, and updated its own mappers accordingly.

Several metadata mappers here still set the Url property via object initializer, leaving RemoteUrl empty, which throws System.UriFormatException: Invalid URI: The URI is empty in MediaCoverService. Switch these mappers to the MediaCovercoverType, url constructor, matching the existing mappers. 

Built and confirmed working with last Lidarr nightly