### PR TITLE
Fix MissingMethodException in ExtendedDownloadDecisionComparer

### DIFF
--- a/Tubifarry/Core/Replacements/ExtendedDownloadDecisionComparer.cs
+++ b/Tubifarry/Core/Replacements/ExtendedDownloadDecisionComparer.cs
@@ -1,6 +1,7 @@
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.Indexers;
+using NzbDrone.Core.Music;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Profiles.Delay;
 using NzbDrone.Core.Profiles.Qualities;
@@ -18,8 +19,9 @@ public sealed class ExtendedDownloadDecisionComparer : DownloadDecisionComparer,
     public ExtendedDownloadDecisionComparer(
         IConfigService configService,
         IDelayProfileService delayProfileService,
-        IQualityDefinitionService qualityDefinitionService)
-        : base(configService, delayProfileService, qualityDefinitionService)
+        IQualityDefinitionService qualityDefinitionService,
+        IAlbumYearMatcher yearMatcher)
+        : base(configService, delayProfileService, qualityDefinitionService, yearMatcher)
     {
         _configService = configService;
         _delayProfileService = delayProfileService;

--- a/Tubifarry/Core/Replacements/ExtendedDownloadDecisionPriorizationService.cs
+++ b/Tubifarry/Core/Replacements/ExtendedDownloadDecisionPriorizationService.cs
@@ -1,5 +1,6 @@
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.DecisionEngine;
+using NzbDrone.Core.Music;
 using NzbDrone.Core.Profiles.Delay;
 using NzbDrone.Core.Qualities;
 
@@ -12,9 +13,10 @@ public class ExtendedDownloadDecisionPriorizationService : IPrioritizeDownloadDe
     public ExtendedDownloadDecisionPriorizationService(
         IConfigService configService,
         IDelayProfileService delayProfileService,
-        IQualityDefinitionService qualityDefinitionService)
+        IQualityDefinitionService qualityDefinitionService,
+        IAlbumYearMatcher yearMatcher)
     {
-        _comparer = new ExtendedDownloadDecisionComparer(configService, delayProfileService, qualityDefinitionService);
+        _comparer = new ExtendedDownloadDecisionComparer(configService, delayProfileService, qualityDefinitionService, yearMatcher);
     }
 
     public List<DownloadDecision> PrioritizeDecisions(List<DownloadDecision> decisions)


### PR DESCRIPTION
## Summary
- Lidarr added a 4th constructor parameter (`IAlbumYearMatcher`) to `NzbDrone.Core.DecisionEngine.DownloadDecisionComparer` for release-year detection (merged into Lidarr `develop` on 2026-08-31).
- Tubifarry's `ExtendedDownloadDecisionComparer` and `ExtendedDownloadDecisionPriorizationService` still called/declared the old 3-arg constructor, so DryIoc throws `MissingMethodException` when resolving `IPrioritizeDownloadDecision` on current Lidarr builds. This breaks `AlbumSearch` and the `GET /api/v1/release?albumId=...` endpoint.
- Updates both classes to accept and forward `IAlbumYearMatcher`.
- Bumps the pinned `Submodules/Lidarr` commit to Lidarr `develop` HEAD so the plugin compiles against a matching constructor signature.

Fixes #219

## Test plan
- [ ] Build against the updated Lidarr submodule and confirm no compile errors
- [ ] Run `AlbumSearch` against a current Lidarr `develop`/nightly build and confirm no `MissingMethodException`
- [ ] Verify `GET /api/v1/release?albumId=...` returns decisions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)