### PR TITLE
Fix Lidarr 3.1.5 compatibility and Discogs metadata handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,59 @@
+# Tubifarry — Lidarr 3.1.5 Compatibility & Discogs Fixes Fork
+
+> [!IMPORTANT]
+> This fork of [TypNull/Tubifarry](https://github.com/TypNull/Tubifarry)
+> contains compatibility fixes for Lidarr 3.1.5, including restored Discogs
+> metadata handling for existing MusicBrainz-backed artists and albums.
+
+### Lidarr 3.1.5 compatibility
+
+Lidarr 3.1.5 changed the constructor dependencies for its download decision
+comparison logic.
+
+This fork updates Tubifarry's replacement download decision classes to support
+the newer signature by injecting and forwarding `IAlbumYearMatcher`.
+
+Affected classes:
+
+- `ExtendedDownloadDecisionComparer`
+- `ExtendedDownloadDecisionPriorizationService`
+
+This keeps Tubifarry's custom download prioritization compatible with
+Lidarr 3.1.5.
+
+### Discogs metadata compatibility
+
+This fork also improves how Tubifarry's Discogs metadata provider works with
+artists and albums that already exist in Lidarr using identifiers from another
+metadata source, such as MusicBrainz.
+
+Previously, the Discogs provider expected the identifiers passed to it to
+already be native Discogs IDs. When Lidarr supplied an existing MusicBrainz
+artist or album ID, Discogs metadata retrieval could fail.
+
+This fork adds resolution of non-Discogs identifiers:
+
+- Existing artists are located in Lidarr and searched for on Discogs by name.
+- Discogs artist search results are fuzzy-matched to the existing artist.
+- Existing albums are searched for using their title and artist.
+- Album search results are fuzzy-matched and resolved to a Discogs master or
+  release ID.
+- Existing Lidarr album metadata and tracks are preserved when Discogs is
+  supplementing an album owned by another metadata source.
+
+### Discogs discography cleanup
+
+The Discogs provider also includes several fixes to produce a cleaner
+discography for Lidarr:
+
+- Collapses duplicate Discogs master/release entries with the same title.
+- Prefers the Discogs master when both a master and individual release exist.
+- Skips CDr promo releases.
+- Filters Discogs `video` entries out of album tracklists.
+
+These changes help Discogs supplement an existing Lidarr library without
+creating duplicate albums or replacing matching-critical metadata.
+
 # Tubifarry for Lidarr 🎶
 ![Downloads](https://img.shields.io/github/downloads/TypNull/Tubifarry/total)  ![GitHub release (latest by date)](https://img.shields.io/github/v/release/TypNull/Tubifarry)  ![GitHub last commit](https://img.shields.io/github/last-commit/TypNull/Tubifarry)  ![License](https://img.shields.io/github/license/TypNull/Tubifarry)  ![GitHub stars](https://img.shields.io/github/stars/TypNull/Tubifarry)
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,14 @@
-# Tubifarry — Lidarr 3.1.5 Compatibility & Discogs Fixes Fork
-
 > [!IMPORTANT]
-> This fork of [TypNull/Tubifarry](https://github.com/TypNull/Tubifarry)
-> contains compatibility fixes for Lidarr 3.1.5, including restored Discogs
-> metadata handling for existing MusicBrainz-backed artists and albums.
+> Tubifarry includes compatibility updates for Lidarr 3.1.5 and improved
+> Discogs metadata handling for existing MusicBrainz-backed artists and albums.
 
 ### Lidarr 3.1.5 compatibility
 
-Lidarr 3.1.5 changed the constructor dependencies for its download decision
+Lidarr 3.1.5 changed the constructor dependencies used by its download decision
 comparison logic.
 
-This fork updates Tubifarry's replacement download decision classes to support
-the newer signature by injecting and forwarding `IAlbumYearMatcher`.
+Tubifarry's replacement download decision classes now support the newer
+signature by injecting and forwarding `IAlbumYearMatcher`.
 
 Affected classes:
 
@@ -23,15 +20,15 @@ Lidarr 3.1.5.
 
 ### Discogs metadata compatibility
 
-This fork also improves how Tubifarry's Discogs metadata provider works with
-artists and albums that already exist in Lidarr using identifiers from another
-metadata source, such as MusicBrainz.
+The Discogs metadata provider can now work with artists and albums that already
+exist in Lidarr using identifiers from another metadata source, such as
+MusicBrainz.
 
-Previously, the Discogs provider expected the identifiers passed to it to
-already be native Discogs IDs. When Lidarr supplied an existing MusicBrainz
-artist or album ID, Discogs metadata retrieval could fail.
+Previously, the Discogs provider expected identifiers passed to it to already
+be native Discogs IDs. When Lidarr supplied an existing MusicBrainz artist or
+album ID, Discogs metadata retrieval could fail.
 
-This fork adds resolution of non-Discogs identifiers:
+Non-Discogs identifiers are now resolved as follows:
 
 - Existing artists are located in Lidarr and searched for on Discogs by name.
 - Discogs artist search results are fuzzy-matched to the existing artist.
@@ -43,16 +40,18 @@ This fork adds resolution of non-Discogs identifiers:
 
 ### Discogs discography cleanup
 
-The Discogs provider also includes several fixes to produce a cleaner
-discography for Lidarr:
+The Discogs provider also applies several filters when constructing a Lidarr
+discography:
 
 - Collapses duplicate Discogs master/release entries with the same title.
 - Prefers the Discogs master when both a master and individual release exist.
 - Skips CDr promo releases.
-- Filters Discogs `video` entries out of album tracklists.
+- Excludes Discogs video entries from album tracklists, including enhanced-CD
+  entries represented with a `Video` track position.
 
-These changes help Discogs supplement an existing Lidarr library without
-creating duplicate albums or replacing matching-critical metadata.
+These changes allow Discogs to supplement an existing Lidarr library without
+creating duplicate albums, counting video content as audio tracks, or replacing
+matching-critical metadata.
 
 # Tubifarry for Lidarr 🎶
 ![Downloads](https://img.shields.io/github/downloads/TypNull/Tubifarry/total)  ![GitHub release (latest by date)](https://img.shields.io/github/v/release/TypNull/Tubifarry)  ![GitHub last commit](https://img.shields.io/github/last-commit/TypNull/Tubifarry)  ![License](https://img.shields.io/github/license/TypNull/Tubifarry)  ![GitHub stars](https://img.shields.io/github/stars/TypNull/Tubifarry)

--- a/Tubifarry/Core/Replacements/ExtendedDownloadDecisionComparer.cs
+++ b/Tubifarry/Core/Replacements/ExtendedDownloadDecisionComparer.cs
@@ -1,6 +1,7 @@
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.Indexers;
+using NzbDrone.Core.Music;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Profiles.Delay;
 using NzbDrone.Core.Profiles.Qualities;
@@ -18,8 +19,9 @@ public sealed class ExtendedDownloadDecisionComparer : DownloadDecisionComparer,
     public ExtendedDownloadDecisionComparer(
         IConfigService configService,
         IDelayProfileService delayProfileService,
-        IQualityDefinitionService qualityDefinitionService)
-        : base(configService, delayProfileService, qualityDefinitionService)
+        IQualityDefinitionService qualityDefinitionService,
+        IAlbumYearMatcher yearMatcher)
+        : base(configService, delayProfileService, qualityDefinitionService, yearMatcher)
     {
         _configService = configService;
         _delayProfileService = delayProfileService;

--- a/Tubifarry/Core/Replacements/ExtendedDownloadDecisionPriorizationService.cs
+++ b/Tubifarry/Core/Replacements/ExtendedDownloadDecisionPriorizationService.cs
@@ -1,5 +1,6 @@
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.DecisionEngine;
+using NzbDrone.Core.Music;
 using NzbDrone.Core.Profiles.Delay;
 using NzbDrone.Core.Qualities;
 
@@ -12,9 +13,10 @@ public class ExtendedDownloadDecisionPriorizationService : IPrioritizeDownloadDe
     public ExtendedDownloadDecisionPriorizationService(
         IConfigService configService,
         IDelayProfileService delayProfileService,
-        IQualityDefinitionService qualityDefinitionService)
+        IQualityDefinitionService qualityDefinitionService,
+        IAlbumYearMatcher yearMatcher)
     {
-        _comparer = new ExtendedDownloadDecisionComparer(configService, delayProfileService, qualityDefinitionService);
+        _comparer = new ExtendedDownloadDecisionComparer(configService, delayProfileService, qualityDefinitionService, yearMatcher);
     }
 
     public List<DownloadDecision> PrioritizeDecisions(List<DownloadDecision> decisions)

--- a/Tubifarry/Metadata/Proxy/MetadataProvider/Discogs/DiscogsMappingHelper.cs
+++ b/Tubifarry/Metadata/Proxy/MetadataProvider/Discogs/DiscogsMappingHelper.cs
@@ -517,7 +517,9 @@ namespace Tubifarry.Metadata.Proxy.MetadataProvider.Discogs
 
         private static List<DiscogsTrack> FilterTracklist(List<DiscogsTrack>? tracklist) => tracklist?
             .Where(t => !string.Equals(t.Type, "heading", StringComparison.OrdinalIgnoreCase) &&
-            !string.Equals(t.Type, "index", StringComparison.OrdinalIgnoreCase))
+            !string.Equals(t.Type, "index", StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(t.Type, "video", StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(t.Position, "video", StringComparison.OrdinalIgnoreCase))
             .ToList() ?? [];
 
         /// <summary>

--- a/Tubifarry/Metadata/Proxy/MetadataProvider/Discogs/DiscogsProxy.cs
+++ b/Tubifarry/Metadata/Proxy/MetadataProvider/Discogs/DiscogsProxy.cs
@@ -160,25 +160,104 @@ namespace Tubifarry.Metadata.Proxy.MetadataProvider.Discogs
 
             Album? existingAlbum = _albumService.FindById(foreignAlbumId);
 
-            bool useMaster = foreignAlbumId.StartsWith('m');
-            _logger.Trace($"Using {(useMaster ? "master" : "release")} details for AlbumId: {foreignAlbumId}");
+            string resolvedAlbumId = foreignAlbumId;
+            string cleanId = RemoveIdentifier(foreignAlbumId);
 
-            DiscogsApiService apiService = new(_httpClient, settings.UserAgent) { AuthToken = settings.AuthToken };
+            bool isDiscogsId =
+                (cleanId.StartsWith('m') || cleanId.StartsWith('r')) &&
+                cleanId.Length > 1 &&
+                int.TryParse(cleanId[1..], out _);
+
+            if (!isDiscogsId)
+            {
+                if (existingAlbum == null || string.IsNullOrWhiteSpace(existingAlbum.Title))
+                    throw new KeyNotFoundException(
+                        $"Unable to resolve non-Discogs album ID '{foreignAlbumId}' because the album was not found in Lidarr.");
+
+                string? artistName = existingAlbum.Artist?.Value?.Name;
+
+                _logger.Debug(
+                    $"Album ID '{foreignAlbumId}' is not a Discogs ID. Searching Discogs for '{existingAlbum.Title}' by '{artistName}'.");
+
+                List<DiscogsSearchItem> matches = await CachedSearchAsync(
+                    settings,
+                    existingAlbum.Title,
+                    item => item,
+                    "all",
+                    artistName);
+
+                DiscogsSearchItem? bestMatch = matches
+                    .Where(item =>
+                        string.Equals(item.Type, "master", StringComparison.OrdinalIgnoreCase) ||
+                        string.Equals(item.Type, "release", StringComparison.OrdinalIgnoreCase))
+                    .OrderByDescending(item =>
+                    {
+                        string candidateTitle = item.Title ?? string.Empty;
+
+                        if (!string.IsNullOrWhiteSpace(artistName))
+                        {
+                            string prefix = artistName + " - ";
+                            if (candidateTitle.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                                candidateTitle = candidateTitle[prefix.Length..];
+                        }
+
+                        return Fuzz.Ratio(candidateTitle, existingAlbum.Title);
+                    })
+                    .FirstOrDefault();
+
+                if (bestMatch == null)
+                    throw new KeyNotFoundException(
+                        $"Unable to map album '{existingAlbum.Title}' [{foreignAlbumId}] to a Discogs release.");
+
+                bool matchedMaster =
+                    string.Equals(bestMatch.Type, "master", StringComparison.OrdinalIgnoreCase);
+
+                resolvedAlbumId =
+                    $"{(matchedMaster ? "m" : "r")}{bestMatch.Id}@discogs";
+
+                _logger.Debug(
+                    $"Mapped album '{existingAlbum.Title}' [{foreignAlbumId}] to Discogs {bestMatch.Type} ID {bestMatch.Id} ('{bestMatch.Title}').");
+            }
+
+            bool useMaster = RemoveIdentifier(resolvedAlbumId).StartsWith('m');
+            _logger.Trace(
+                $"Using {(useMaster ? "master" : "release")} details for AlbumId: {resolvedAlbumId}");
+
+            DiscogsApiService apiService = new(_httpClient, settings.UserAgent)
+            {
+                AuthToken = settings.AuthToken
+            };
 
             (Album mappedAlbum, object releaseForTracks) = useMaster
-                ? await GetMasterReleaseDetailsAsync(foreignAlbumId, apiService)
-                : await GetReleaseDetailsAsync(foreignAlbumId, apiService);
+                ? await GetMasterReleaseDetailsAsync(resolvedAlbumId, apiService)
+                : await GetReleaseDetailsAsync(resolvedAlbumId, apiService);
 
-            DiscogsArtist? discogsArtist = await GetPrimaryArtistAsync(foreignAlbumId, useMaster, existingAlbum);
+            DiscogsArtist? discogsArtist =
+                await GetPrimaryArtistAsync(resolvedAlbumId, useMaster, existingAlbum);
 
             Artist existingArtist = (existingAlbum?.Artist?.Value ?? (discogsArtist != null ? DiscogsMappingHelper.MapArtistFromDiscogsArtist(discogsArtist) : null))
-                ?? throw new ModelNotFoundException(typeof(Artist), 0);
+                  ?? throw new ModelNotFoundException(typeof(Artist), 0);
             _logger.Trace($"Processed artist information for ArtistId: {existingArtist.ForeignArtistId}");
             existingArtist.Albums ??= new LazyLoaded<List<Album>>([]);
 
             mappedAlbum.Artist = existingArtist;
             mappedAlbum.ArtistMetadata = existingArtist.Metadata;
             mappedAlbum.ArtistMetadataId = existingArtist.ArtistMetadataId;
+
+            // If Lidarr requested an existing non-Discogs album (for example a
+            // MusicBrainz UUID), preserve its matching-critical metadata and tracks.
+            // Discogs should supplement the discography, not replace metadata for
+            // albums already owned by another metadata source.
+            if (!isDiscogsId && existingAlbum != null)
+            {
+                _logger.Debug(
+                    $"Preserving existing metadata for non-Discogs AlbumId: {foreignAlbumId}; resolved Discogs match was {resolvedAlbumId}.");
+
+                return new Tuple<string, Album, List<ArtistMetadata>>(
+                    existingArtist.ForeignArtistId,
+                    existingAlbum,
+                    [existingArtist.Metadata.Value]);
+            }
 
             Album finalAlbum = DiscogsMappingHelper.MergeAlbums(existingAlbum!, mappedAlbum);
             AlbumRelease albumRelease = finalAlbum.AlbumReleases.Value[0];
@@ -226,19 +305,52 @@ namespace Tubifarry.Metadata.Proxy.MetadataProvider.Discogs
             _logger.Debug($"Fetching artist info for ID: {foreignArtistId}.");
             UpdateCache(settings);
 
-            string artistCacheKey = $"artist:{foreignArtistId}" + _identifier;
+            Artist? existingArtist = _artistService.FindById(foreignArtistId);
+
+            string cleanId = RemoveIdentifier(foreignArtistId);
+            if (cleanId.Length > 1 && !char.IsDigit(cleanId[0]))
+                cleanId = cleanId[1..];
+
+            int discogsArtistId;
+
+            if (!int.TryParse(cleanId, out discogsArtistId))
+            {
+                if (existingArtist == null || string.IsNullOrWhiteSpace(existingArtist.Name))
+                    throw new KeyNotFoundException($"Unable to resolve non-Discogs artist ID '{foreignArtistId}' because the artist was not found in Lidarr.");
+
+                _logger.Debug($"Artist ID '{foreignArtistId}' is not a Discogs ID. Searching Discogs for '{existingArtist.Name}'.");
+
+                List<DiscogsSearchItem> matches = await CachedSearchAsync(
+                    settings,
+                    existingArtist.Name,
+                    item => item,
+                    "artist",
+                    null);
+
+                DiscogsSearchItem? bestMatch = matches
+                    .OrderByDescending(item => Fuzz.Ratio(item.Title ?? string.Empty, existingArtist.Name))
+                    .FirstOrDefault();
+
+                if (bestMatch == null)
+                    throw new KeyNotFoundException($"Unable to map artist '{existingArtist.Name}' [{foreignArtistId}] to a Discogs artist.");
+
+                discogsArtistId = bestMatch.Id;
+
+                _logger.Debug($"Mapped artist '{existingArtist.Name}' [{foreignArtistId}] to Discogs artist ID {discogsArtistId} ('{bestMatch.Title}').");
+            }
+
+            string artistCacheKey = $"artist:{discogsArtistId}" + _identifier;
             DiscogsArtist? artist = await _cache.FetchAndCacheAsync<DiscogsArtist>(artistCacheKey, () =>
             {
                 DiscogsApiService apiService = new(_httpClient, settings.UserAgent) { AuthToken = settings.AuthToken };
-                string cleanId = RemoveIdentifier(foreignArtistId);
-                if (cleanId.Length > 1 && !char.IsDigit(cleanId[0]))
-                    cleanId = cleanId[1..];
-                return apiService.GetArtistAsync(int.Parse(cleanId))!;
+                return apiService.GetArtistAsync(discogsArtistId)!;
             });
 
-            Artist? existingArtist = _artistService.FindById(foreignArtistId);
-            existingArtist ??= DiscogsMappingHelper.MapArtistFromDiscogsArtist(artist!);
-            existingArtist.Albums = AlbumMapper.FilterAlbums(await FetchAlbumsForArtistAsync(settings, existingArtist, artist!.Id), metadataProfileId, _metadataProfileService);
+            if (artist == null)
+                throw new KeyNotFoundException($"Discogs artist ID {discogsArtistId} could not be retrieved.");
+
+            existingArtist ??= DiscogsMappingHelper.MapArtistFromDiscogsArtist(artist);
+            existingArtist.Albums = await FetchAlbumsForArtistAsync(settings, existingArtist, artist.Id);
             existingArtist.MetadataProfileId = metadataProfileId;
 
             _logger.Trace($"Processed artist: {artist.Name} (ID: {existingArtist.ForeignArtistId}).");
@@ -256,12 +368,60 @@ namespace Tubifarry.Metadata.Proxy.MetadataProvider.Discogs
                 return apiService.GetArtistReleasesAsync(foreignArtistId, null, 70);
             });
 
-            List<Album> albums = [];
+            // Discogs can return both a master and one or more individual
+            // releases for the same logical album. Exposing both to Lidarr
+            // creates duplicate Album rows that may be deleted while an import
+            // is still referencing them. Collapse exact-title duplicates here,
+            // preferring the master when one exists.
+            Dictionary<string, DiscogsArtistRelease> mainReleases = new(StringComparer.OrdinalIgnoreCase);
+
             foreach (DiscogsArtistRelease release in artistReleases)
             {
                 if (release == null || release.Role != "Main")
                     continue;
 
+                bool isCdrPromo =
+                    release.Format?.Contains("CDr", StringComparison.OrdinalIgnoreCase) == true &&
+                    release.Format.Contains("Promo", StringComparison.OrdinalIgnoreCase);
+
+                if (isCdrPromo)
+                {
+                    _logger.Debug(
+                        $"Skipping Discogs CDr promo release {release.Id} ('{release.Title}').");
+                    continue;
+                }
+
+                string titleKey = release.Title?.Trim() ?? string.Empty;
+
+                if (string.IsNullOrWhiteSpace(titleKey))
+                    titleKey = $"{release.Type}:{release.Id}";
+
+                if (!mainReleases.TryGetValue(titleKey, out DiscogsArtistRelease? existing))
+                {
+                    mainReleases[titleKey] = release;
+                    continue;
+                }
+
+                bool existingIsMaster = string.Equals(existing.Type, "master", StringComparison.OrdinalIgnoreCase);
+                bool candidateIsMaster = string.Equals(release.Type, "master", StringComparison.OrdinalIgnoreCase);
+
+                if (!existingIsMaster && candidateIsMaster)
+                {
+                    _logger.Debug(
+                        $"Replacing duplicate Discogs release {existing.Id} with master {release.Id} for '{release.Title}'.");
+
+                    mainReleases[titleKey] = release;
+                }
+                else
+                {
+                    _logger.Debug(
+                        $"Skipping duplicate Discogs {release.Type} {release.Id} for '{release.Title}'; keeping {existing.Type} {existing.Id}.");
+                }
+            }
+
+            List<Album> albums = [];
+            foreach (DiscogsArtistRelease release in mainReleases.Values)
+            {
                 Album album = DiscogsMappingHelper.MapAlbumFromArtistRelease(release);
                 album.Artist = artist;
                 album.ArtistMetadata = artist.Metadata;
@@ -279,3 +439,4 @@ namespace Tubifarry.Metadata.Proxy.MetadataProvider.Discogs
         private static string RemoveIdentifier(string input) => input.EndsWith(_identifier, StringComparison.OrdinalIgnoreCase) ? input.Remove(input.Length - _identifier.Length) : input;
     }
 }
+


### PR DESCRIPTION
## Summary

This PR updates Tubifarry for Lidarr 3.1.5.5066 and fixes several Discogs metadata issues encountered when using MusicBrainz-backed artists and albums.

## Changes

- Update Lidarr compatibility for 3.1.5.5066
  - Adjust replacement constructors for current Lidarr APIs
  - Update the Lidarr submodule target

- Fix Discogs artist lookup for MusicBrainz UUIDs
  - Avoid parsing MusicBrainz UUIDs as numeric Discogs artist IDs
  - Resolve existing Lidarr artists to Discogs artists by name when needed

- Fix Discogs album lookup for MusicBrainz UUIDs
  - Resolve MusicBrainz-backed albums to matching Discogs releases/masters
  - Normalize resolved Discogs IDs before fetching release details

- Preserve existing MusicBrainz metadata for MBID-originated album lookups
  - Prevent Discogs metadata from replacing matching-critical existing album/release metadata

- Improve Discogs artist release population
  - Include useful Discogs Main releases that may be absent from MusicBrainz
  - Preserve singles, EPs, splits, and other legitimate Main releases

- Deduplicate Discogs masters and releases
  - Collapse exact-title duplicates
  - Prefer a master over an individual release when both represent the same album

- Filter CDr promo releases
  - Exclude `CDr, Promo` Main releases while leaving other promo formats untouched

- Filter enhanced/video entries from tracklists
  - Ignore entries with `type=video`
  - Ignore entries with `position=Video`
  - Preserve existing heading/index filtering

## Testing

Built against Lidarr 3.1.5.5066 and tested with a live Lidarr installation.

Regression cases included:

- MusicBrainz UUID-backed artist lookup
- MusicBrainz UUID-backed album lookup
- Discogs-only releases missing from MusicBrainz
- Duplicate Discogs master/release entries
- CDr promo releases
- Enhanced CDs containing video entries represented as normal Discogs tracks

The resulting plugin loaded successfully and the affected artists/albums refreshed and imported correctly.
