### PR TITLE
Fix PlaylistExport failing to save with InvalidCastException

### DIFF
--- a/Tubifarry/Notifications/PlaylistExport/PlaylistExportService.cs
+++ b/Tubifarry/Notifications/PlaylistExport/PlaylistExportService.cs
@@ -9,6 +9,7 @@ using NzbDrone.Core.Notifications;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.ThingiProvider.Events;
 using System.Text;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using Tubifarry.Core.Model;
 using Tubifarry.Core.Utilities;
@@ -94,6 +95,49 @@ public sealed partial class PlaylistExportService : IPlaylistExportService,
         RefreshSchema();
     }
 
+    /// <summary>
+    /// Converts a dynamic field value to a bool.
+    /// </summary>
+    /// <remarks>
+    /// Values arriving from a notification POST are JsonElement, which does not implement
+    /// IConvertible, so Convert.ToBoolean throws InvalidCastException and saving the connection
+    /// fails from both the UI and the API.
+    ///
+    /// The type cannot be matched with a pattern: plugins load in their own AssemblyLoadContext,
+    /// so the JsonElement the host passes in is a different Type instance from the one this
+    /// assembly sees, and "value is JsonElement" is false. Match on the type name and read the
+    /// textual form instead, which is "true" or "false" for a JSON boolean.
+    /// </remarks>
+    private static bool ToBoolean(object? value)
+    {
+        switch (value)
+        {
+            case null:
+                return false;
+            case bool b:
+                return b;
+            case string str:
+                return bool.TryParse(str, out bool fromString) && fromString;
+        }
+
+        if (value.GetType().FullName == "System.Text.Json.JsonElement")
+        {
+            string text = value.ToString() ?? string.Empty;
+            return bool.TryParse(text, out bool fromJson)
+                ? fromJson
+                : text.Length > 0 && text != "0" && text != "null";
+        }
+
+        try
+        {
+            return Convert.ToBoolean(value);
+        }
+        catch (InvalidCastException)
+        {
+            return false;
+        }
+    }
+
     public void RefreshSchema()
     {
         List<IImportList> allLists = _importListFactory.GetAvailableProviders();
@@ -117,7 +161,7 @@ public sealed partial class PlaylistExportService : IPlaylistExportService,
                 },
                 PropertyType = typeof(bool),
                 GetterFunc = m => ((PlaylistExportSettings)m).GetBoolState(key),
-                SetterFunc = (m, v) => ((PlaylistExportSettings)m).SetBoolState(key, Convert.ToBoolean(v)),
+                SetterFunc = (m, v) => ((PlaylistExportSettings)m).SetBoolState(key, ToBoolean(v)),
             });
         }
 


### PR DESCRIPTION
Playlist Export can't be saved. The connection fails from both the UI and the API.

The `list_*` checkboxes built in `RefreshSchema` go through `Convert.ToBoolean`, but the values coming back from a notification POST are `JsonElement`, which doesn't implement `IConvertible`:

```
POST /api/v1/notification
System.InvalidCastException: Unable to cast object of type
'System.Text.Json.JsonElement' to type 'System.IConvertible'.
   at Tubifarry.Notifications.PlaylistExport.PlaylistExportService
      .<>c__DisplayClass15_0.<RefreshSchema>b__1(Object m, Object v)
   at Lidarr.Http.ClientSchema.SchemaBuilder.ReadFromSchema(...)
```

I hit this on Lidarr 3.1.5.5066 with Tubifarry 2.1.1. The same line is in 2.2.0.5 and on develop. Sending the field as a JSON bool, a string or a number all fail the same way, because it never reaches the setter as a primitive.

`value is JsonElement` does not work here. I tried it first and got the same exception. Plugins load in their own `AssemblyLoadContext`, so the `JsonElement` the host passes in is a different `Type` than the plugin sees, and the pattern never matches. Matching on the type name does work. `Convert.ToBoolean` stays as a fallback, so values that already worked are unchanged.

Tested on a live instance built against 3.1.5.5066. Saving returned 500 before the change and 201 after.
