### PR TITLE
Fix PlaylistExport producing no playlist files

### DIFF
--- a/Tubifarry/Core/Model/PlaylistItem.cs
+++ b/Tubifarry/Core/Model/PlaylistItem.cs
@@ -6,7 +6,8 @@ public record PlaylistItem(
     string ArtistName,
     string? AlbumTitle,
     string? TrackTitle = null,
-    string? ForeignRecordingId = null);
+    string? ForeignRecordingId = null,
+    string? PlaylistName = null);
 
 public record PlaylistSnapshot(
     string ListName,

--- a/Tubifarry/ImportLists/Spotify/SpotifyUserPlaylistImport.cs
+++ b/Tubifarry/ImportLists/Spotify/SpotifyUserPlaylistImport.cs
@@ -209,7 +209,7 @@ namespace NzbDrone.Core.ImportLists.Spotify
             {
                 Paging<PlaylistTrack> tracks = GetPlaylistTracksWithRetry(api, playlist.Id);
                 if (tracks != null)
-                    AppendTrackItems(api, tracks, result);
+                    AppendTrackItems(api, tracks, result, playlist.Name);
             }
 
             if (page.HasNextPage())
@@ -220,7 +220,7 @@ namespace NzbDrone.Core.ImportLists.Spotify
             }
         }
 
-        private void AppendTrackItems(SpotifyWebAPI api, Paging<PlaylistTrack> tracks, List<PlaylistItem> result)
+        private void AppendTrackItems(SpotifyWebAPI api, Paging<PlaylistTrack> tracks, List<PlaylistItem> result, string playlistName)
         {
             if (tracks.Items == null) return;
 
@@ -242,14 +242,15 @@ namespace NzbDrone.Core.ImportLists.Spotify
                     AlbumMusicBrainzId: null,
                     ArtistName: artistName,
                     AlbumTitle: album.Name,
-                    TrackTitle: trackTitle));
+                    TrackTitle: trackTitle,
+                    PlaylistName: playlistName));
             }
 
             if (tracks.HasNextPage())
             {
                 Paging<PlaylistTrack> next = GetNextPageWithRetry(api, tracks);
                 if (next != null)
-                    AppendTrackItems(api, next, result);
+                    AppendTrackItems(api, next, result, playlistName);
             }
         }
 

--- a/Tubifarry/Notifications/PlaylistExport/PlaylistExportService.cs
+++ b/Tubifarry/Notifications/PlaylistExport/PlaylistExportService.cs
@@ -206,15 +206,27 @@ public sealed partial class PlaylistExportService : IPlaylistExportService,
                 continue;
             }
 
-            if (!snapshots.TryGetValue(listId, out PlaylistSnapshot? snapshot))
+            PlaylistSnapshot? snapshot = GetOrRefreshSnapshot(listId, allLists, snapshots);
+            if (snapshot == null)
             {
-                _logger.Warn($"No snapshot for list {listId}: fetch has not run yet for this list.");
+                _logger.Warn($"No snapshot for list {listId}: the fetch returned nothing.");
                 continue;
             }
 
-            List<TrackFile> files = [];
+            // One file per source playlist. Items from a list that does not name a
+            // playlist all land under the list's own name, which is one file for the
+            // whole list, as before.
+            Dictionary<string, List<TrackFile>> byPlaylist = [];
+
             foreach (PlaylistItem item in snapshot.Items)
             {
+                string playlistName = string.IsNullOrWhiteSpace(item.PlaylistName)
+                    ? snapshot.ListName
+                    : item.PlaylistName;
+
+                if (!byPlaylist.TryGetValue(playlistName, out List<TrackFile>? files))
+                    byPlaylist[playlistName] = files = [];
+
                 bool useTrackLevel = trackMode != PlaylistTrackMode.AlbumDataOnly
                     && (item.TrackTitle != null || item.ForeignRecordingId != null);
 
@@ -249,8 +261,40 @@ public sealed partial class PlaylistExportService : IPlaylistExportService,
                 }
             }
 
-            WriteM3u8(outputPath, snapshot.ListName, files, settings.UseRelativePaths);
+            foreach ((string playlistName, List<TrackFile> files) in byPlaylist)
+                WriteM3u8(outputPath, playlistName, files, settings.UseRelativePaths);
         }
+    }
+
+    /// <summary>
+    /// Returns the stored snapshot for a list, fetching one first when it is absent or
+    /// older than the list's own refresh interval.
+    /// </summary>
+    /// <remarks>
+    /// Nothing else in the pipeline writes snapshots, and the export runs on album
+    /// import, which is not a fetch. Without this the store stays empty and no list
+    /// ever produces a file. The interval bounds it, so a burst of imports does not
+    /// become one upstream fetch per album.
+    /// </remarks>
+    private PlaylistSnapshot? GetOrRefreshSnapshot(
+        int listId,
+        List<IImportList> allLists,
+        Dictionary<int, PlaylistSnapshot> snapshots)
+    {
+        snapshots.TryGetValue(listId, out PlaylistSnapshot? snapshot);
+
+        IImportList? list = allLists.FirstOrDefault(l => l.Definition.Id == listId);
+        if (list == null)
+        {
+            _logger.Warn($"Import list ID {listId} not found");
+            return snapshot;
+        }
+
+        if (snapshot != null && DateTime.UtcNow - snapshot.FetchedAt < list.MinRefreshInterval)
+            return snapshot;
+
+        FetchAndStore(listId);
+        return GetSnapshots().GetValueOrDefault(listId) ?? snapshot;
     }
 
     private List<PlaylistItem> FetchAlbumLevelItems(IImportList list)
@@ -303,14 +347,27 @@ public sealed partial class PlaylistExportService : IPlaylistExportService,
     private static string Normalize(string? s) =>
         s == null ? "" : NormalizeRegex().Replace(s.ToLowerInvariant(), "");
 
+    // No BOM: Encoding.UTF8 puts three bytes in front of #EXTM3U, so the first
+    // line stops matching the header a strict m3u reader looks for.
+    private static readonly UTF8Encoding _utf8NoBom = new(false);
+
     private void WriteM3u8(string outputPath, string listName, List<TrackFile> files, bool useRelative)
     {
+        List<TrackFile> present = files.Where(f => File.Exists(f.Path)).ToList();
+        if (present.Count == 0)
+        {
+            // A playlist whose tracks are all missing locally would otherwise be
+            // written as a header and imported as an empty playlist.
+            _logger.Debug($"Skipping '{listName}': no local files for any of its {files.Count} track(s)");
+            return;
+        }
+
         string filename = SanitizeFilename(listName) + ".m3u8";
         string fullPath = Path.Combine(outputPath, filename);
 
         List<string> lines = ["#EXTM3U", $"#PLAYLIST:{listName}"];
 
-        foreach (TrackFile tf in files.Where(f => File.Exists(f.Path)))
+        foreach (TrackFile tf in present)
         {
             string displayName = Path.GetFileNameWithoutExtension(tf.Path);
             string trackPath = useRelative
@@ -320,8 +377,8 @@ public sealed partial class PlaylistExportService : IPlaylistExportService,
             lines.Add(trackPath);
         }
 
-        File.WriteAllLines(fullPath, lines, Encoding.UTF8);
-        _logger.Info($"Written {files.Count} track(s) to '{fullPath}'");
+        File.WriteAllLines(fullPath, lines, _utf8NoBom);
+        _logger.Info($"Written {present.Count} track(s) to '{fullPath}'");
     }
 
     private static string? FindCommonRoot(List<string> paths)


### PR DESCRIPTION
PlaylistExport never wrote a playlist file for me. There were four problems.

Nothing writes the snapshot store. `GeneratePlaylists` reads snapshots out of plugin settings, and the only method that writes them is `FetchAndStore(int listId)`, which has no callers anywhere in the plugin. A list that does not implement `IPlaylistTrackSource` is skipped earlier when the mode is Track Data Only. Every other selected list reaches `No snapshot for list N: fetch has not run yet for this list`. `GeneratePlaylists` now fetches when a snapshot is missing or older than the list's `MinRefreshInterval`. The age check is there so a run of imports does not become one upstream fetch per album.

`SpotifyUserPlaylistImport.FetchTrackLevelItems()` walks every playlist the user has saved and appends all of their tracks to a single `List<PlaylistItem>`. `PlaylistItem` has no field for the playlist a track came from, and `WriteM3u8` names the file after the import list, so the most one list can produce is a single m3u8 holding every track of every saved playlist. `PlaylistItem` gains a `PlaylistName`, `AppendTrackItems` fills it in, and the export groups on it before writing. Items with no name fall back to the list name, so album-level lists and `ListenBrainzPlaylistImportList` behave as they did.

The files begin with a BOM. `File.WriteAllLines(path, lines, Encoding.UTF8)` emits `EF BB BF` in front of `#EXTM3U`, so the first line stops matching the header a strict m3u reader looks for. I found this while chasing something else and have not proven which players reject it, but there is no reason to write it. It uses `UTF8Encoding(false)` now.

A playlist with no local files still got written, as a two-line file that imports as an empty playlist. 14 of my 41 were like that. `WriteM3u8` returns early now, and its log line counts what it actually wrote.

Tested on Lidarr 3.1.5.5066 against a Spotify Saved Playlists list holding 3882 items across 41 playlists. It wrote 27 files, one for each playlist that had anything local, 603 tracks in total. Roon imported them.

A Playlist Export connection cannot be saved at all until #223 goes in, so both are needed to reach this code.
